### PR TITLE
[DM-23286] Upgrade nginx-ingress chart to 1.29.7

### DIFF
--- a/deployments/nginx-ingress/requirements.yaml
+++ b/deployments/nginx-ingress/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: nginx-ingress
-  version: 1.18.0
+  version: 1.29.7
   repository: https://kubernetes-charts.storage.googleapis.com


### PR DESCRIPTION
The current nginx TLS configuration allows TLS 1.0 and 1.1, as well
as some weaker ciphers, and therefore only achieves a grade of B
in SSL Labs.  The new version of the Helm chart updates the TLS
configuration to only allow TLS 1.2 and 1.3 and refreshes the
cipher list.