### PR TITLE
[DM-23286] Work around nginx clusterIP bug

### DIFF
--- a/deployments/nginx-ingress/values.yaml
+++ b/deployments/nginx-ingress/values.yaml
@@ -2,3 +2,14 @@ nginx-ingress:
   controller:
     metrics:
       enabled: true
+
+# Work around upgrade issue (https://github.com/helm/charts/pull/13646)
+nginx-ingress-default-backend:
+  service:
+    clusterIP: "10.4.39.46"
+nginx-ingress-controller-metrics:
+  service:
+    clusterIP: "10.4.46.235"
+nginx-ingress-controller:
+  service:
+    clusterIP: "10.4.40.37"


### PR DESCRIPTION
The nginx-ingress Helm chart has reintroduced an issue with
clusterIP on upgrades that was previously fixed.  The clusterIP
has to be hard-coded to successfully upgrade unless the prior
version was installed with omitClusterIP, which it wasn't for our
configuration.

Hard-code the existing clusterIPs for now until upstream finds a
better fix.