### PR TITLE
[DM-23270] Add vault.lsst.codes to Vault ingress

### DIFF
--- a/deployments/vault/values.yaml
+++ b/deployments/vault/values.yaml
@@ -20,9 +20,13 @@ vault:
       tls:
         - secretName: vault-ingress-tls
           hosts:
+            - vault.lsst.codes
             - vault-1.lsst.codes
             - vault-2.lsst.codes
       hosts:
+        - host: vault.lsst.codes
+          paths:
+            - "/"
         - host: vault-1.lsst.codes
           paths:
             - "/"


### PR DESCRIPTION
Enable vault.lsst.codes as an additional hostname for the Vault
ingress.  This will also trigger acquiring a Let's Encrypt
certificate.  This should not interfere with the existing Vault
server, since it's using a *.lsst.codes wildcard certificate.

The DNS entry for vault.lsst.codes must be changed to point to
Roundtable before this is merged so that the Let's Encrypt
certificate validation will succeed.