### PR TITLE
[DM-23217] Update logging to new chart

### DIFF
--- a/deployments/logging/Chart.yaml
+++ b/deployments/logging/Chart.yaml
@@ -1,0 +1,2 @@
+name: logging
+version: 0.0.1

--- a/deployments/logging/charts/opendistro-es/.helmignore
+++ b/deployments/logging/charts/opendistro-es/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+*.tgz
+# Helm files
+OWNERS

--- a/deployments/logging/charts/opendistro-es/Chart.yaml
+++ b/deployments/logging/charts/opendistro-es/Chart.yaml
@@ -1,0 +1,13 @@
+appVersion: 1.0.0
+description: Open Distro for Elasticsearch
+engine: gotpl
+kubeVersion: ^1.10.0-0
+maintainers:
+- email: derek.heldt-werle@viasat.com
+  name: Derek Heldt-Werle
+- email: kalvin.chau@viasat.com
+  name: Kalvin Chau
+name: opendistro-es
+sources:
+- https://pages.git.viasat.com/ATG/charts
+version: 1.1.0

--- a/deployments/logging/charts/opendistro-es/LICENSE
+++ b/deployments/logging/charts/opendistro-es/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/deployments/logging/charts/opendistro-es/templates/_helpers.tpl
+++ b/deployments/logging/charts/opendistro-es/templates/_helpers.tpl
@@ -1,0 +1,125 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Copyright 2019 Viasat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "opendistro-es.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "opendistro-es.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+Define standard labels for frequently used metadata.
+*/}}
+{{- define "opendistro-es.labels.standard" -}}
+app: {{ template "opendistro-es.fullname" . }}
+chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+release: "{{ .Release.Name }}"
+heritage: "{{ .Release.Service }}"
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "opendistro-es.kibana.serviceAccountName" -}}
+{{- if .Values.kibana.serviceAccount.create -}}
+    {{ default (include "opendistro-es.fullname" .) .Values.kibana.serviceAccount.name }}-kibana
+{{- else -}}
+    {{ default "default" .Values.kibana.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "opendistro-es.elasticsearch.serviceAccountName" -}}
+{{- if .Values.elasticsearch.serviceAccount.create -}}
+    {{ default (include "opendistro-es.fullname" .) .Values.elasticsearch.serviceAccount.name }}-es
+{{- else -}}
+    {{ default "default" .Values.elasticsearch.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "opendistro-es.imagePullSecrets" -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
+Also, we can not use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- else if or .Values.kibana.imagePullSecrets .Values.elasticsearch.imagePullSecrets .Values.elasticsearch.initContainer.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.kibana.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.elasticsearch.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.elasticsearch.initContainer.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- else if or .Values.kibana.imagePullSecrets .Values.elasticsearch.imagePullSecrets .Values.elasticsearch.initContainer.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.kibana.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.elasticsearch.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.elasticsearch.initContainer.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{- define "master-nodes" -}}
+{{- template "opendistro-es.fullname" . -}}-master
+{{- end -}}
+
+{{- define "initial-master-nodes" -}}
+{{- $replicas := .Values.elasticsearch.master.replicas | int }}
+  {{- range $i, $e := untilStep 0 $replicas 1 -}}
+    {{ template "master-nodes" $ }}-{{ $i }},
+  {{- end -}}
+{{- end -}}

--- a/deployments/logging/charts/opendistro-es/templates/elasticsearch/elasticsearch-serviceaccount.yaml
+++ b/deployments/logging/charts/opendistro-es/templates/elasticsearch/elasticsearch-serviceaccount.yaml
@@ -1,0 +1,24 @@
+# Copyright 2019 Viasat, Inc.
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+{{ if .Values.elasticsearch.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "opendistro-es.elasticsearch.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+{{ end }}
+

--- a/deployments/logging/charts/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
+++ b/deployments/logging/charts/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
@@ -1,0 +1,195 @@
+# Copyright 2019 Viasat, Inc.
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+{{- if .Values.elasticsearch.client.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+    role: client
+  name: {{ template "opendistro-es.fullname" . }}-client
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.elasticsearch.client.replicas }}
+  selector: 
+    matchLabels:
+{{ include "opendistro-es.labels.standard" . | indent 6 }}
+      role: client
+  template:
+    metadata:
+      labels:
+{{ include "opendistro-es.labels.standard" . | indent 8 }}
+        role: client
+      annotations:
+        {{/* This forces a restart if the secret config has changed */}}
+        {{- if .Values.elasticsearch.config }}
+        configchecksum: {{ include (print .Template.BasePath "/elasticsearch/es-config-secret.yaml") . | sha256sum | trunc 63 }}
+        {{- end }}
+{{- if .Values.elasticsearch.client.podAnnotations }}
+{{ toYaml .Values.elasticsearch.client.podAnnotations | indent 8 }}
+{{- end }}
+    spec:
+{{- include "opendistro-es.imagePullSecrets" . | indent 6 }}
+      serviceAccountName: {{ template "opendistro-es.elasticsearch.serviceAccountName" . }}
+    {{- with .Values.elasticsearch.client.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.elasticsearch.client.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      # Weighted anti-affinity to disallow deploying client node to the same worker node as master node
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: "kubernetes.io/hostname"
+                labelSelector:
+                  matchLabels:
+                    role: client
+      {{- with .Values.elasticsearch.client.nodeAffinity }}
+        nodeAffinity:
+{{ toYaml . | indent 10 }}
+      {{- end }}
+      initContainers:
+      - name: init-sysctl
+        image: {{ .Values.elasticsearch.initContainer.image }}:{{ .Values.elasticsearch.initContainer.imageTag }}
+        command:
+        - sysctl
+        - -w
+        - vm.max_map_count={{ .Values.elasticsearch.maxMapCount }}
+        securityContext:
+          privileged: true
+      containers:
+      - name: elasticsearch
+        env:
+        - name: cluster.name
+          value: {{ .Values.global.clusterName }}
+        - name: node.master
+          value: "false"
+        - name: node.ingest
+          value: "true"
+        - name: node.data
+          value: "false"
+        - name: network.host
+          value: "0.0.0.0"
+        - name: node.name
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: discovery.seed_hosts
+          value: {{ template "opendistro-es.fullname" . }}-discovery
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PROCESSORS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: ES_JAVA_OPTS
+          value: {{ .Values.elasticsearch.client.javaOpts }}
+{{- if .Values.elasticsearch.extraEnvs }}
+{{ toYaml .Values.elasticsearch.extraEnvs | indent 8 }}
+{{- end }}
+        resources:
+{{ toYaml .Values.elasticsearch.client.resources | indent 12 }}
+        # Official Image from Open Distro Team
+        image: {{ .Values.elasticsearch.image }}:{{ .Values.elasticsearch.imageTag }}
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 9200
+          name: http
+        - containerPort: 9300
+          name: transport
+        - containerPort: 9600
+          name: metrics
+    {{- with .Values.elasticsearch.client.readinessProbe}}
+        readinessProbe:
+{{ toYaml . | indent 10 }}
+    {{- end }}
+    {{- with .Values.elasticsearch.client.livenessProbe}}
+        livenessProbe:
+{{ toYaml . | indent 10 }}
+    {{- end }}
+        volumeMounts:
+        {{- if .Values.elasticsearch.config }}
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/elasticsearch.yml
+          name: config
+          subPath: elasticsearch.yml
+        {{- end }}
+        {{- if .Values.elasticsearch.log4jConfig }}
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/log4j2.properties
+          name: config
+          subPath: log4j2.properties
+        {{- end }}
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/logging.yml
+          name: config
+          subPath: logging.yml
+        {{- if and .Values.elasticsearch.ssl.transport.enabled .Values.elasticsearch.ssl.transport.existingCertSecret }}
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-crt.pem
+          name: transport-certs
+          subPath: elk-transport-crt.pem
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-key.pem
+          name: transport-certs
+          subPath: elk-transport-key.pem
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-root-ca.pem
+          name: transport-certs
+          subPath: elk-transport-root-ca.pem
+         {{- end }}
+         {{- if and .Values.elasticsearch.ssl.rest.enabled .Values.elasticsearch.ssl.rest.existingCertSecret }}
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-rest-crt.pem
+          name: rest-certs
+          subPath: elk-rest-crt.pem
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-rest-key.pem
+          name: rest-certs
+          subPath: elk-rest-key.pem
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-rest-root-ca.pem
+          name: rest-certs
+          subPath: elk-rest-root-ca.pem
+        {{- end }}
+        {{- if and .Values.elasticsearch.ssl.admin.enabled .Values.elasticsearch.ssl.admin.existingCertSecret }}
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/admin-crt.pem
+          name: admin-certs
+          subPath: admin-crt.pem
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/admin-key.pem
+          name: admin-certs
+          subPath: admin-key.pem
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/admin-root-ca.pem
+          name: admin-certs
+          subPath: admin-root-ca.pem
+        {{- end }}
+      volumes:
+      - name: config
+        secret:
+          secretName: {{ template "opendistro-es.fullname" . }}-es-config
+      {{- if and .Values.elasticsearch.ssl.transport.enabled .Values.elasticsearch.ssl.transport.existingCertSecret }}
+      - name: transport-certs
+        secret:
+          secretName: {{ .Values.elasticsearch.ssl.transport.existingCertSecret }}
+      {{- end }}
+      {{- if and .Values.elasticsearch.ssl.rest.enabled .Values.elasticsearch.ssl.rest.existingCertSecret }}
+      - name: rest-certs
+        secret:
+          secretName: {{ .Values.elasticsearch.ssl.rest.existingCertSecret }}
+      {{- end }}
+      {{- if and .Values.elasticsearch.ssl.admin.enabled .Values.elasticsearch.ssl.admin.existingCertSecret }}
+      - name: admin-certs
+        secret:
+          secretName: {{ .Values.elasticsearch.ssl.admin.existingCertSecret }}
+      {{- end }}
+{{- end }}

--- a/deployments/logging/charts/opendistro-es/templates/elasticsearch/es-client-ingress.yaml
+++ b/deployments/logging/charts/opendistro-es/templates/elasticsearch/es-client-ingress.yaml
@@ -1,0 +1,48 @@
+# Copyright 2019 Viasat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+{{- if and .Values.elasticsearch.client.ingress.enabled .Values.elasticsearch.client.enabled }}
+{{ $fullName := printf "%s-%s"  (include "opendistro-es.fullname" .) "client-service" }}
+{{ $ingressPath := .Values.elasticsearch.client.ingress.path }}
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: {{ $fullName }}
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+{{- with .Values.elasticsearch.client.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.elasticsearch.client.ingress.tls }}
+  tls:
+  {{- range .Values.elasticsearch.client.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.elasticsearch.client.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/deployments/logging/charts/opendistro-es/templates/elasticsearch/es-client-pdb.yaml
+++ b/deployments/logging/charts/opendistro-es/templates/elasticsearch/es-client-pdb.yaml
@@ -1,0 +1,33 @@
+# Copyright 2019 Viasat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+{{- if and .Values.elasticsearch.client.podDisruptionBudget.enabled .Values.elasticsearch.client.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "opendistro-es.fullname" . }}-client-pdb
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+spec:
+{{- if .Values.elasticsearch.client.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.client.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.elasticsearch.client.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.elasticsearch.client.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "opendistro-es.fullname" . }}
+      role: client
+{{- end }}

--- a/deployments/logging/charts/opendistro-es/templates/elasticsearch/es-config-secret.yaml
+++ b/deployments/logging/charts/opendistro-es/templates/elasticsearch/es-config-secret.yaml
@@ -1,0 +1,30 @@
+# Copyright 2019 Viasat, Inc.
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "opendistro-es.fullname" . }}-es-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+type: Opaque
+data:
+  {{- if .Values.elasticsearch.config }}
+  elasticsearch.yml: {{ toYaml .Values.elasticsearch.config | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.elasticsearch.log4jConfig }}
+  log4j2.properties: {{ .Values.elasticsearch.log4jConfig | b64enc | quote }}
+  {{- end }}
+  logging.yml: {{ toYaml .Values.elasticsearch.loggingConfig | b64enc | quote }}

--- a/deployments/logging/charts/opendistro-es/templates/elasticsearch/es-data-pdb.yaml
+++ b/deployments/logging/charts/opendistro-es/templates/elasticsearch/es-data-pdb.yaml
@@ -1,0 +1,33 @@
+# Copyright 2019 Viasat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+{{- if and .Values.elasticsearch.data.podDisruptionBudget.enabled .Values.elasticsearch.data.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "opendistro-es.fullname" . }}-data-pdb
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+spec:
+{{- if .Values.elasticsearch.data.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.data.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.elasticsearch.data.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.elasticsearch.data.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "opendistro-es.fullname" . }}
+      role: data
+{{- end }}

--- a/deployments/logging/charts/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/deployments/logging/charts/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -1,0 +1,212 @@
+# Copyright 2019 Viasat, Inc.
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+{{ if .Values.elasticsearch.data.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+    role: data
+  name: {{ template "opendistro-es.fullname" . }}-data
+  namespace: {{ .Release.Namespace }}
+spec:
+  serviceName: {{ template "opendistro-es.fullname" . }}-data-svc
+  replicas: {{ .Values.elasticsearch.data.replicas }}
+  selector: 
+    matchLabels:
+{{ include "opendistro-es.labels.standard" . | indent 6 }}
+      role: data
+  updateStrategy:
+    type: {{ .Values.elasticsearch.data.updateStrategy }}
+  template:
+    metadata:
+      labels:
+{{ include "opendistro-es.labels.standard" . | indent 8 }}
+        role: data
+      annotations:
+        {{/* This forces a restart if the secret config has changed */}}
+        {{- if .Values.elasticsearch.config }}
+        configchecksum: {{ include (print .Template.BasePath "/elasticsearch/es-config-secret.yaml") . | sha256sum | trunc 63 }}
+        {{- end }}
+{{- if .Values.elasticsearch.data.podAnnotations }}
+{{ toYaml .Values.elasticsearch.data.podAnnotations | indent 8 }}
+{{- end }}
+    spec:
+{{- include "opendistro-es.imagePullSecrets" . | indent 6 }}
+    {{- with .Values.elasticsearch.data.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.elasticsearch.data.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      initContainers:
+      - name: init-sysctl
+        image: {{ .Values.elasticsearch.initContainer.image }}:{{ .Values.elasticsearch.initContainer.imageTag }}
+        command:
+        - sysctl
+        - -w
+        - vm.max_map_count={{ .Values.elasticsearch.maxMapCount }}
+        securityContext:
+          privileged: true
+      - name: fixmount
+        command: [ 'sh', '-c', 'chown -R 1000:1000 /usr/share/elasticsearch/data' ]
+        image: {{ .Values.elasticsearch.initContainer.image }}:{{ .Values.elasticsearch.initContainer.imageTag }}
+        volumeMounts:
+          - mountPath: /usr/share/elasticsearch/data
+            name: data
+      # Weighted anti-affinity to disallow deploying client node to the same worker node as master node
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  role: data
+      {{- with .Values.elasticsearch.data.nodeAffinity }}
+        nodeAffinity:
+{{ toYaml . | indent 10 }}
+      {{- end }}
+      serviceAccountName: {{ template "opendistro-es.elasticsearch.serviceAccountName" . }}
+      containers:
+      - name: elasticsearch
+        env:
+        - name: cluster.name
+          value: {{ .Values.global.clusterName }}
+        - name: node.master
+          value: "false"
+        - name: node.ingest
+          value: "false"
+        - name: network.host
+          value: "0.0.0.0"
+        - name: node.name
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: discovery.seed_hosts
+          value: {{ .Values.elasticsearch.discoveryOverride | default (printf "%s-discovery" (include "opendistro-es.fullname" .)) | quote }}
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: node.data
+          value: "true"
+        - name: PROCESSORS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: ES_JAVA_OPTS
+          value: {{ .Values.elasticsearch.data.javaOpts }}
+{{- if .Values.elasticsearch.extraEnvs }}
+{{ toYaml .Values.elasticsearch.extraEnvs | indent 8 }}
+{{- end }}
+        # Official Image from Open Distro Team
+        image: {{ .Values.elasticsearch.image }}:{{ .Values.elasticsearch.imageTag }}
+        imagePullPolicy: Always
+        # only publish the transport port
+        ports:
+        - containerPort: 9300
+          name: transport
+        resources:
+{{ toYaml .Values.elasticsearch.data.resources | indent 12 }}
+    {{- with .Values.elasticsearch.data.readinessProbe}}
+        readinessProbe:
+{{ toYaml . | indent 10 }}
+    {{- end }}
+    {{- with .Values.elasticsearch.data.livenessProbe}}
+        livenessProbe:
+{{ toYaml . | indent 10 }}
+    {{- end }}
+        volumeMounts:
+        - mountPath: /usr/share/elasticsearch/data
+          name: data
+        {{- if .Values.elasticsearch.config }}
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/elasticsearch.yml
+          name: config
+          subPath: elasticsearch.yml
+        {{- end }}
+        {{- if .Values.elasticsearch.log4jConfig }}
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/log4j2.properties
+          name: config
+          subPath: log4j2.properties
+        {{- end }}
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/logging.yml
+          name: config
+          subPath: logging.yml
+         {{- if and .Values.elasticsearch.ssl.transport.enabled .Values.elasticsearch.ssl.transport.existingCertSecret }}
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-crt.pem
+          name: transport-certs
+          subPath: elk-transport-crt.pem
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-key.pem
+          name: transport-certs
+          subPath: elk-transport-key.pem
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-root-ca.pem
+          name: transport-certs
+          subPath: elk-transport-root-ca.pem
+         {{- end }}
+         {{- if and .Values.elasticsearch.ssl.rest.enabled .Values.elasticsearch.ssl.rest.existingCertSecret }}
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-rest-crt.pem
+          name: rest-certs
+          subPath: elk-rest-crt.pem
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-rest-key.pem
+          name: rest-certs
+          subPath: elk-rest-key.pem
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-rest-root-ca.pem
+          name: rest-certs
+          subPath: elk-rest-root-ca.pem
+         {{- end }}
+         {{- if and .Values.elasticsearch.ssl.admin.enabled .Values.elasticsearch.ssl.admin.existingCertSecret }}
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/admin-crt.pem
+          name: admin-certs
+          subPath: admin-crt.pem
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/admin-key.pem
+          name: admin-certs
+          subPath: admin-key.pem
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/admin-root-ca.pem
+          name: admin-certs
+          subPath: admin-root-ca.pem
+         {{- end }}
+      volumes:
+      - name: config
+        secret:
+          secretName: {{ template "opendistro-es.fullname" . }}-es-config
+      {{- if and .Values.elasticsearch.ssl.transport.enabled .Values.elasticsearch.ssl.transport.existingCertSecret }}
+      - name: transport-certs
+        secret:
+          secretName: {{ .Values.elasticsearch.ssl.transport.existingCertSecret }}
+      {{- end }}
+      {{- if and .Values.elasticsearch.ssl.rest.enabled .Values.elasticsearch.ssl.rest.existingCertSecret }}
+      - name: rest-certs
+        secret:
+          secretName: {{ .Values.elasticsearch.ssl.rest.existingCertSecret }}
+      {{- end }}
+      {{- if and .Values.elasticsearch.ssl.admin.enabled .Values.elasticsearch.ssl.admin.existingCertSecret }}
+      - name: admin-certs
+        secret:
+          secretName: {{ .Values.elasticsearch.ssl.admin.existingCertSecret }}
+      {{- end }}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ ReadWriteOnce ]
+      storageClassName: {{ .Values.elasticsearch.data.storageClassName }}
+      resources:
+        requests:
+          storage: {{ .Values.elasticsearch.data.storage }}
+{{- end }}

--- a/deployments/logging/charts/opendistro-es/templates/elasticsearch/es-data-svc.yaml
+++ b/deployments/logging/charts/opendistro-es/templates/elasticsearch/es-data-svc.yaml
@@ -1,0 +1,35 @@
+# Copyright 2019 Viasat, Inc.
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+{{- if .Values.elasticsearch.data.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+    role: data
+  name: {{ template "opendistro-es.fullname" . }}-data-svc
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - port: 9300
+    name: transport
+  - port: 9200
+    name: http
+  - port: 9600
+    name: metrics
+  clusterIP: None
+  selector:
+    role: data
+{{- end }}

--- a/deployments/logging/charts/opendistro-es/templates/elasticsearch/es-master-pdb.yaml
+++ b/deployments/logging/charts/opendistro-es/templates/elasticsearch/es-master-pdb.yaml
@@ -1,0 +1,33 @@
+# Copyright 2019 Viasat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+{{- if and .Values.elasticsearch.master.podDisruptionBudget.enabled .Values.elasticsearch.master.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "opendistro-es.fullname" . }}-master-pdb
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+spec:
+{{- if .Values.elasticsearch.master.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.master.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.elasticsearch.master.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.elasticsearch.master.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "opendistro-es.fullname" . }}
+      role: master
+{{- end }}

--- a/deployments/logging/charts/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/deployments/logging/charts/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -1,0 +1,285 @@
+# Copyright 2019 Viasat, Inc.
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+{{- if .Values.elasticsearch.master.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+    role: master
+  name: {{ template "opendistro-es.fullname" . }}-master
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.elasticsearch.master.replicas }}
+  selector: 
+    matchLabels:
+{{ include "opendistro-es.labels.standard" . | indent 6 }}
+      role: master
+  updateStrategy:
+    type: {{ .Values.elasticsearch.master.updateStrategy }}
+  serviceName: {{ template "opendistro-es.fullname" . }}-discovery
+  template:
+    metadata:
+      labels:
+{{ include "opendistro-es.labels.standard" . | indent 8 }}
+        role: master
+      annotations:
+        {{/* This forces a restart if the secret config has changed */}}
+        {{- if .Values.elasticsearch.config }}
+        configchecksum: {{ include (print .Template.BasePath "/elasticsearch/es-config-secret.yaml") . | sha256sum | trunc 63 }}
+        {{- end }}
+{{- if .Values.elasticsearch.master.podAnnotations }}
+{{ toYaml .Values.elasticsearch.master.podAnnotations | indent 8 }}
+{{- end }}
+    spec:
+{{- include "opendistro-es.imagePullSecrets" . | indent 6 }}
+      serviceAccountName: {{ template "opendistro-es.elasticsearch.serviceAccountName" . }}
+    {{- with .Values.elasticsearch.master.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.elasticsearch.master.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      # Anti-affinity to disallow deploying client and master nodes on the same worker node
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: "kubernetes.io/hostname"
+            labelSelector:
+              matchLabels:
+                role: master
+      {{- with .Values.elasticsearch.master.nodeAffinity }}
+        nodeAffinity:
+{{ toYaml . | indent 10 }}
+      {{- end }}
+      initContainers:
+      - name: init-sysctl
+        image: {{ .Values.elasticsearch.initContainer.image }}:{{ .Values.elasticsearch.initContainer.imageTag }}
+        command:
+        - sysctl
+        - -w
+        - vm.max_map_count={{ .Values.elasticsearch.maxMapCount }}
+        securityContext:
+          privileged: true
+      - name: fixmount
+        command: [ 'sh', '-c', 'chown -R 1000:1000 /usr/share/elasticsearch/data' ]
+        image: {{ .Values.elasticsearch.initContainer.image }}:{{ .Values.elasticsearch.initContainer.imageTag }}
+        volumeMounts:
+          - mountPath: /usr/share/elasticsearch/data
+            name: data
+      containers:
+      - name: elasticsearch
+        env:
+        - name: cluster.name
+          value: {{ .Values.global.clusterName }}
+        - name: cluster.initial_master_nodes
+          value: {{ template "initial-master-nodes" . }}
+        - name: node.master
+          value: "true"
+        - name: node.ingest
+          value: "false"
+        - name: node.data
+          value: "false"
+        - name: network.host
+          value: "0.0.0.0"
+    {{- if .Values.elasticsearch.transportKeyPassphrase.enabled}}
+        - name: TRANSPORT_KEY_PASSPHRASE
+          value: {{ .Values.elasticsearch.keyPassphrase.passPhrase }}
+    {{- end }}
+    {{- if .Values.elasticsearch.transportKeyPassphrase.enabled}}
+        - name: SSL_KEY_PASSPHRASE
+          value: {{ .Values.elasticsearch.sslKeyPassphrase.passPhrase }}
+    {{- end }}
+        - name: node.name
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: discovery.seed_hosts
+          value: {{ template "opendistro-es.fullname" . }}-discovery
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PROCESSORS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: ES_JAVA_OPTS
+          value: {{ .Values.elasticsearch.master.javaOpts }}
+{{- if .Values.elasticsearch.extraEnvs }}
+{{ toYaml .Values.elasticsearch.extraEnvs | indent 8 }}
+{{- end }}
+        resources:
+{{ toYaml .Values.elasticsearch.master.resources | indent 12 }}
+    {{- with .Values.elasticsearch.master.readinessProbe}}
+        readinessProbe:
+{{ toYaml . | indent 10 }}
+    {{- end }}
+    {{- with .Values.elasticsearch.master.livenessProbe}}
+        livenessProbe:
+{{ toYaml . | indent 10 }}
+    {{- end }}
+        # Official Image from Open Distro Team
+        image: {{ .Values.elasticsearch.image }}:{{ .Values.elasticsearch.imageTag }}
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 9300
+          name: transport
+        - containerPort: 9200
+          name: http
+        - containerPort: 9600
+          name: metrics
+        volumeMounts:
+        - mountPath: /usr/share/elasticsearch/data
+          name: data
+        {{- if .Values.elasticsearch.config }}
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/elasticsearch.yml
+          name: config
+          subPath: elasticsearch.yml
+        {{- end }}
+        {{- if .Values.elasticsearch.log4jConfig }}
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/log4j2.properties
+          name: config
+          subPath: log4j2.properties
+        {{- end }}
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/logging.yml
+          name: config
+          subPath: logging.yml
+        {{- if and .Values.elasticsearch.ssl.transport.enabled .Values.elasticsearch.ssl.transport.existingCertSecret }}
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-crt.pem
+          name: transport-certs
+          subPath: elk-transport-crt.pem
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-key.pem
+          name: transport-certs
+          subPath: elk-transport-key.pem
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-root-ca.pem
+          name: transport-certs
+          subPath: elk-transport-root-ca.pem
+         {{- end }}
+         {{- if and .Values.elasticsearch.ssl.rest.enabled .Values.elasticsearch.ssl.rest.existingCertSecret }}
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-rest-crt.pem
+          name: rest-certs
+          subPath: elk-rest-crt.pem
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-rest-key.pem
+          name: rest-certs
+          subPath: elk-rest-key.pem
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-rest-root-ca.pem
+          name: rest-certs
+          subPath: elk-rest-root-ca.pem
+        {{- end }}
+        {{- if and .Values.elasticsearch.ssl.admin.enabled .Values.elasticsearch.ssl.admin.existingCertSecret }}
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/admin-crt.pem
+          name: admin-certs
+          subPath: admin-crt.pem
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/admin-key.pem
+          name: admin-certs
+          subPath: admin-key.pem
+        - mountPath: {{ .Values.elasticsearch.configDirectory }}/admin-root-ca.pem
+          name: admin-certs
+          subPath: admin-root-ca.pem
+       {{- end }}
+      {{- if .Values.elasticsearch.securityConfig.enabled }}
+      {{- if .Values.elasticsearch.securityConfig.actionGroupsSecret }}
+        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/action_groups.yml
+          name: action-groups
+          subPath: action_groups.yml
+       {{- end }}
+       {{- if .Values.elasticsearch.securityConfig.configSecret }}
+        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/config.yml
+          name: security-config
+          subPath: config.yml
+       {{- end }}
+       {{- if .Values.elasticsearch.securityConfig.internalUsersSecret }}
+        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/internal_users.yml
+          name: internal-users-config
+          subPath: internal_users.yml
+       {{- end }}
+       {{- if .Values.elasticsearch.securityConfig.rolesSecret }}
+        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/roles.yml
+          name: roles
+          subPath: roles.yml
+       {{- end }}
+       {{- if .Values.elasticsearch.securityConfig.rolesMappingSecret }}
+        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/roles_mapping.yml
+          name: role-mapping
+          subPath: roles_mapping.yml
+      {{- end }}
+       {{- if .Values.elasticsearch.securityConfig.tenantsSecret }}
+        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/tenants.yml
+          name: tenants
+          subPath: tenants.yml
+      {{- end }}
+      {{- end }}
+      volumes:
+      - name: config
+        secret:
+          secretName: {{ template "opendistro-es.fullname" . }}-es-config
+      {{- if and .Values.elasticsearch.ssl.transport.enabled .Values.elasticsearch.ssl.transport.existingCertSecret }}
+      - name: transport-certs
+        secret:
+          secretName: {{ .Values.elasticsearch.ssl.transport.existingCertSecret }}
+      {{- end }}
+      {{- if and .Values.elasticsearch.ssl.rest.enabled .Values.elasticsearch.ssl.rest.existingCertSecret }}
+      - name: rest-certs
+        secret:
+          secretName: {{ .Values.elasticsearch.ssl.rest.existingCertSecret }}
+      {{- end }}
+      {{- if and .Values.elasticsearch.ssl.admin.enabled .Values.elasticsearch.ssl.admin.existingCertSecret }}
+      - name: admin-certs
+        secret:
+          secretName: {{ .Values.elasticsearch.ssl.admin.existingCertSecret }}
+      {{- end }}
+      {{- if .Values.elasticsearch.securityConfig.actionGroupsSecret }}
+      - name: action-groups
+        secret:
+          secretName: {{ .Values.elasticsearch.securityConfig.actionGroupsSecret }}
+      {{- end }}
+      {{- if .Values.elasticsearch.securityConfig.configSecret }}
+      - name: security-config
+        secret:
+          secretName: {{ .Values.elasticsearch.securityConfig.configSecret }}
+      {{- end }}
+      {{- if .Values.elasticsearch.securityConfig.internalUsersSecret }}
+      - name: internal-users-config
+        secret:
+          secretName: {{ .Values.elasticsearch.securityConfig.internalUsersSecret }}
+      {{- end }}
+      {{- if .Values.elasticsearch.securityConfig.rolesSecret }}
+      - name: roles
+        secret:
+          secretName: {{ .Values.elasticsearch.securityConfig.rolesSecret }}
+      {{- end }}
+      {{- if .Values.elasticsearch.securityConfig.rolesMappingSecret }}
+      - name: role-mapping
+        secret:
+          secretName: {{ .Values.elasticsearch.securityConfig.rolesMappingSecret }}
+      {{- end -}}
+      {{- if .Values.elasticsearch.securityConfig.tenantsSecret }}
+      - name: tenants
+        secret:
+          secretName: {{ .Values.elasticsearch.securityConfig.tenantsSecret }}
+      {{- end }}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ ReadWriteOnce ]
+      storageClassName: {{ .Values.elasticsearch.master.storageClassName }}
+      resources:
+        requests:
+          storage: {{ .Values.elasticsearch.master.storage }}
+{{- end }}

--- a/deployments/logging/charts/opendistro-es/templates/elasticsearch/es-service.yaml
+++ b/deployments/logging/charts/opendistro-es/templates/elasticsearch/es-service.yaml
@@ -1,0 +1,37 @@
+# Copyright 2019 Viasat, Inc.
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+{{- if .Values.elasticsearch.client.enabled }}
+kind: Service
+apiVersion: v1
+metadata:
+  annotations:
+{{ toYaml .Values.elasticsearch.client.service.annotations | indent 4 }}
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+    role: client
+  name: {{ template "opendistro-es.fullname" . }}-client-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+    - name: http
+      port: 9200
+    - name: transport
+      port: 9300
+    - name: metrics
+      port: 9600
+  selector:
+    role: client
+  type: {{ .Values.elasticsearch.client.service.type }}
+{{- end }}

--- a/deployments/logging/charts/opendistro-es/templates/elasticsearch/master-svc.yaml
+++ b/deployments/logging/charts/opendistro-es/templates/elasticsearch/master-svc.yaml
@@ -1,0 +1,31 @@
+# Copyright 2019 Viasat, Inc.
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+{{- if .Values.elasticsearch.master.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+    role: master
+  name: {{ template "opendistro-es.fullname" . }}-discovery
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+    - port: 9300
+      protocol: TCP
+  clusterIP: None
+  selector:
+    role: master
+{{- end }}

--- a/deployments/logging/charts/opendistro-es/templates/elasticsearch/role.yaml
+++ b/deployments/logging/charts/opendistro-es/templates/elasticsearch/role.yaml
@@ -1,0 +1,28 @@
+# Copyright 2019 Viasat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+{{- if .Values.global.rbac.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ template "opendistro-es.elasticsearch.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "opendistro-es.fullname" . }}-psp
+{{- end }}

--- a/deployments/logging/charts/opendistro-es/templates/elasticsearch/rolebinding.yaml
+++ b/deployments/logging/charts/opendistro-es/templates/elasticsearch/rolebinding.yaml
@@ -1,0 +1,29 @@
+# Copyright 2019 Viasat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+{{- if .Values.global.rbac.enabled }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+  name: {{ template "opendistro-es.fullname" . }}-elastic-rolebinding
+roleRef:
+  kind: Role
+  name: {{ template "opendistro-es.elasticsearch.serviceAccountName" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ template "opendistro-es.elasticsearch.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deployments/logging/charts/opendistro-es/templates/kibana/kibana-config-secret.yaml
+++ b/deployments/logging/charts/opendistro-es/templates/kibana/kibana-config-secret.yaml
@@ -1,0 +1,25 @@
+# Copyright 2019 Viasat, Inc.
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+{{- if and .Values.kibana.enabled .Values.kibana.config }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "opendistro-es.fullname" . }}-kibana-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+data:
+  kibana.yml: {{ toYaml .Values.kibana.config | b64enc }}
+{{- end }}

--- a/deployments/logging/charts/opendistro-es/templates/kibana/kibana-deployment.yaml
+++ b/deployments/logging/charts/opendistro-es/templates/kibana/kibana-deployment.yaml
@@ -1,0 +1,141 @@
+# Copyright 2019 Viasat, Inc.
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+{{- if .Values.kibana.enabled }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+  name: {{ template "opendistro-es.fullname" . }}-kibana
+spec:
+  replicas: {{ .Values.kibana.replicas }}
+  template:
+    metadata:
+      labels:
+{{ include "opendistro-es.labels.standard" . | indent 8 }}
+        app: {{ template "opendistro-es.fullname" . }}-kibana
+      annotations:
+        {{/* This forces a restart if the secret config has changed */}}
+        {{- if .Values.kibana.config }}
+        checksum/config: {{ include (print .Template.BasePath "/kibana/kibana-config-secret.yaml") . | sha256sum | trunc 63 }}
+        {{- end }}
+    spec:
+{{- include "opendistro-es.imagePullSecrets" . | indent 6 }}
+      containers:
+      - env:
+        - name: CLUSTER_NAME
+          value: {{ .Values.global.clusterName }}
+        # If no custom configuration provided, default to internal DNS
+        {{- if not .Values.kibana.config }}
+        - name: ELASTICSEARCH_HOSTS
+          value: https://{{ template "opendistro-es.fullname" . }}-client-service:9200
+        {{- end }}
+        {{- if .Values.kibana.elasticsearchAccount.secret }}
+        - name: ELASTICSEARCH_USERNAME
+          valueFrom:
+             secretKeyRef:
+               name: {{ .Values.kibana.elasticsearchAccount.secret }}
+               key: username
+        - name: ELASTICSEARCH_PASSWORD
+          valueFrom:
+             secretKeyRef:
+               name: {{ .Values.kibana.elasticsearchAccount.secret }}
+               key: password
+      {{- if and .Values.kibana.elasticsearchAccount.keyPassphrase.enabled }}
+        - name: KEY_PASSPHRASE
+          valueFrom:
+             secretKeyRef:
+               name: {{ .Values.kibana.elasticsearchAccount.secret }}
+               key: keypassphrase
+        # 32-character random string to be used as cookie password by security plugin
+      {{- end }}
+        - name: COOKIE_PASS
+          valueFrom:
+             secretKeyRef:
+               name: {{ .Values.kibana.elasticsearchAccount.secret }}
+               key: cookie
+      {{- end }}
+{{- if .Values.kibana.extraEnvs }}
+{{ toYaml .Values.kibana.extraEnvs | indent 8 }}
+{{- end }}
+        image: {{ .Values.kibana.image }}:{{ .Values.kibana.imageTag }}
+    {{- with .Values.kibana.readinessProbe}}
+        readinessProbe:
+{{ toYaml . | indent 10 }}
+    {{- end }}
+    {{- with .Values.kibana.livenessProbe}}
+        livenessProbe:
+{{ toYaml . | indent 10 }}
+    {{- end }}
+        resources:
+{{ toYaml .Values.kibana.resources | indent 12 }}
+        name: {{ template "opendistro-es.fullname" . }}-kibana
+        volumeMounts:
+         {{- if .Values.kibana.config }}
+          - mountPath: {{ .Values.kibana.configDirectory }}/kibana.yml
+            name: config
+            subPath: kibana.yml
+         {{- end }}
+         {{- if and .Values.kibana.ssl.kibana.enabled .Values.kibana.ssl.kibana.existingCertSecret }}
+          - mountPath: {{ .Values.kibana.certsDirectory }}/kibana-crt.pem
+            name: kibana-certs
+            subPath: kibana-crt.pem
+          - mountPath: {{ .Values.kibana.certsDirectory }}/kibana-key.pem
+            name: kibana-certs
+            subPath: kibana-key.pem
+          - mountPath: {{ .Values.kibana.certsDirectory }}/kibana-root-ca.pem
+            name: kibana-certs
+            subPath: kibana-root-ca.pem
+         {{- end }}
+         {{- if and .Values.kibana.ssl.elasticsearch.enabled .Values.kibana.ssl.elasticsearch.existingCertSecret }}
+          - mountPath: {{ .Values.kibana.certsDirectory }}/elk-rest-crt.pem
+            name: elasticsearch-certs
+            subPath: elk-rest-crt.pem
+          - mountPath: {{ .Values.kibana.certsDirectory }}/elk-rest-key.pem
+            name: elasticsearch-certs
+            subPath: elk-rest-key.pem
+          - mountPath: {{ .Values.kibana.certsDirectory }}/elk-rest-root-ca.pem
+            name: elasticsearch-certs
+            subPath: elk-rest-root-ca.pem
+         {{- end }}
+        ports:
+        - containerPort: {{ .Values.kibana.port }}
+      serviceAccountName: {{ template "opendistro-es.kibana.serviceAccountName" . }}
+      volumes:
+        {{- if .Values.kibana.config }}
+        - name: config
+          secret:
+            secretName: {{ template "opendistro-es.fullname" . }}-kibana-config
+        {{- end }}
+        {{- if and .Values.kibana.ssl.kibana.enabled .Values.kibana.ssl.kibana.existingCertSecret }}
+        - name: kibana-certs
+          secret:
+            secretName: {{ .Values.kibana.ssl.kibana.existingCertSecret }}
+        {{- end }}
+        {{- if and .Values.kibana.ssl.elasticsearch.enabled .Values.kibana.ssl.elasticsearch.existingCertSecret }}
+        - name: elasticsearch-certs
+          secret:
+            secretName: {{ .Values.kibana.ssl.elasticsearch.existingCertSecret }}
+        {{- end }}
+    {{- with .Values.kibana.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.kibana.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      restartPolicy: Always
+{{ end }}

--- a/deployments/logging/charts/opendistro-es/templates/kibana/kibana-ingress.yml
+++ b/deployments/logging/charts/opendistro-es/templates/kibana/kibana-ingress.yml
@@ -1,0 +1,44 @@
+# Copyright 2019 Viasat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+{{- if and .Values.kibana.ingress.enabled .Values.kibana.enabled }}
+{{- $serviceName:= printf "%s-%s"  (include "opendistro-es.fullname" .) "kibana-svc" }}
+{{- $servicePort := .Values.kibana.externalPort }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+  name: {{ template "opendistro-es.fullname" . }}-kibana
+  annotations:
+    {{- range $key, $value := .Values.kibana.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range .Values.kibana.ingress.hosts }}
+      {{- $url := splitList "/" . }}
+    - host: {{ first $url }}
+      http:
+        paths:
+          - path: /{{ rest $url | join "/" }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.kibana.ingress.tls }}
+  tls:
+{{ toYaml .Values.kibana.ingress.tls | indent 4 }}
+  {{- end }}
+{{- end }}
+

--- a/deployments/logging/charts/opendistro-es/templates/kibana/kibana-service.yaml
+++ b/deployments/logging/charts/opendistro-es/templates/kibana/kibana-service.yaml
@@ -1,0 +1,32 @@
+# Copyright 2019 Viasat, Inc.
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+{{- if .Values.kibana.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+{{ toYaml .Values.kibana.service.annotations | indent 4 }}
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+  name: {{ template "opendistro-es.fullname" . }}-kibana-svc
+spec:
+  ports:
+  - name: kibana-svc
+    port: {{ .Values.kibana.externalPort }}
+    targetPort: {{ .Values.kibana.port }}
+  selector:
+    app: {{ template "opendistro-es.fullname" . }}-kibana
+  type: {{ .Values.kibana.service.type }}
+{{- end }}

--- a/deployments/logging/charts/opendistro-es/templates/kibana/kibana-serviceaccount.yaml
+++ b/deployments/logging/charts/opendistro-es/templates/kibana/kibana-serviceaccount.yaml
@@ -1,0 +1,22 @@
+# Copyright 2019 Viasat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+{{ if and .Values.kibana.serviceAccount.create .Values.kibana.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "opendistro-es.kibana.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+{{ end -}}

--- a/deployments/logging/charts/opendistro-es/templates/kibana/role.yaml
+++ b/deployments/logging/charts/opendistro-es/templates/kibana/role.yaml
@@ -1,0 +1,28 @@
+# Copyright 2019 Viasat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+{{- if and .Values.global.rbac.enabled .Values.kibana.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ template "opendistro-es.kibana.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "opendistro-es.fullname" . }}-psp
+{{- end }}

--- a/deployments/logging/charts/opendistro-es/templates/kibana/rolebinding.yaml
+++ b/deployments/logging/charts/opendistro-es/templates/kibana/rolebinding.yaml
@@ -1,0 +1,29 @@
+# Copyright 2019 Viasat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+{{- if and .Values.global.rbac.enabled .Values.kibana.enabled }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+  name: {{ template "opendistro-es.fullname" . }}-kibana-rolebinding
+roleRef:
+  kind: Role
+  name: {{ template "opendistro-es.kibana.serviceAccountName" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ template "opendistro-es.kibana.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deployments/logging/charts/opendistro-es/templates/psp.yml
+++ b/deployments/logging/charts/opendistro-es/templates/psp.yml
@@ -1,0 +1,49 @@
+# Copyright 2019 Viasat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+{{- if .Values.global.psp.create }}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+  name: {{ template "opendistro-es.fullname" . }}-psp
+spec:
+  privileged: true
+  #requiredDropCapabilities:
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/deployments/logging/charts/opendistro-es/values.yaml
+++ b/deployments/logging/charts/opendistro-es/values.yaml
@@ -1,0 +1,358 @@
+# Copyright 2019 Viasat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+kibana:
+  enabled: true
+  image: amazon/opendistro-for-elasticsearch-kibana
+  imageTag: 1.2.0
+  replicas: 1
+  port: 5601
+  externalPort: 443
+  resources:
+    limits:
+      cpu: 2500m
+      memory: 2Gi
+    requests:
+      cpu: 500m
+      memory: 512Mi
+  readinessProbe: []
+  livenessProbe: []
+
+  elasticsearchAccount:
+    secret: ""
+    keyPassphrase:
+      enabled: false
+
+  extraEnvs: []
+
+  ssl:
+    kibana:
+      enabled: false
+      existingCertSecret:
+    elasticsearch:
+      enabled: false
+      existingCertSecret:
+
+
+
+  configDirectory: "/usr/share/kibana/config"
+  certsDirectory: "/usr/share/kibana/certs"
+
+  ingress:
+    enabled: false
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    labels: {}
+    path: /
+    hosts:
+      - chart-example.local
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+  service:
+    type: ClusterIP
+    annotations: {}
+
+  config: {}
+    ## Default Kibana configuration from kibana-docker.
+    # server.name: kibana
+    # server.host: "0"
+
+    ## Replace with Elasticsearch DNS name picked during Service deployment
+    # elasticsearch.hosts: ${ELASTIC_URL}
+    # elasticsearch.requestTimeout: 360000
+
+    ## Kibana TLS Config
+    # server.ssl.enabled: true
+    # server.ssl.key: /usr/share/kibana/certs/kibana-key.pem
+    # server.ssl.certificate: /usr/share/kibana/certs/kibana-crt.pem
+    # elasticsearch.ssl.certificateAuthorities: /usr/share/kibana/certs/kibana-root-ca.pem
+
+    # opendistro_security.cookie.secure: true
+    # opendistro_security.cookie.password: ${COOKIE_PASS}
+
+
+
+  ## Node labels for pod assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  #
+  nodeSelector: {}
+
+  ## Tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+
+  serviceAccount:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    # The name of the ServiceAccount to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name:
+
+
+global:
+  clusterName: elasticsearch
+
+  psp:
+    create: true
+
+  rbac:
+    enabled: true
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  # imagePullSecrets:
+  #   - myRegistryKeySecretName
+
+
+elasticsearch:
+  ## Used when deploying hot/warm architecture. Allows second aliased deployment to find cluster.
+  ## Default {{ template opendistro-es.fullname }}-discovery.
+  discoveryOverride: ""
+  securityConfig:
+    enabled: true
+    path: "/usr/share/elasticsearch/plugins/opendistro_security/securityconfig"
+    actionGroupsSecret:
+    configSecret:
+    internalUsersSecret:
+    rolesSecret:
+    rolesMappingSecret:
+    tenantsSecret:
+
+  extraEnvs: []
+
+  initContainer:
+    image: busybox
+    imageTag: 1.27.2
+
+  ssl:
+    transport:
+      enabled: false
+      existingCertSecret:
+    rest:
+      enabled: false
+      existingCertSecret:
+    admin:
+      enabled: false
+      existingCertSecret:
+
+  master:
+    enabled: true
+    replicas: 3
+    updateStrategy: "RollingUpdate"
+    nodeAffinity: {}
+    storageClassName: gp2-encrypted
+    storage: 50Gi
+    resources:
+      limits:
+        cpu: 1
+        memory: 1024Mi
+      requests:
+        cpu: 200m
+        memory: 1024Mi
+    javaOpts: "-Xms512m -Xmx512m"
+    podDisruptionBudget:
+      enabled: false
+      minAvailable: 1
+    tolerations: []
+    readinessProbe: []
+    livenessProbe:
+      tcpSocket:
+        port: transport
+      initialDelaySeconds: 60
+      periodSeconds: 10
+    nodeSelector: {}
+    podAnnotations: {}
+
+  data:
+    enabled: true
+    replicas: 3
+    updateStrategy: "RollingUpdate"
+    nodeAffinity: {}
+    storageClassName: gp2-encrypted
+    storage: 100Gi
+    resources:
+      limits:
+        cpu: 1
+        memory: 1024Mi
+      requests:
+        cpu: 200m
+        memory: 1024Mi
+    javaOpts: "-Xms512m -Xmx512m"
+    podDisruptionBudget:
+      enabled: false
+      minAvailable: 1
+    tolerations: []
+    readinessProbe: []
+    livenessProbe:
+      tcpSocket:
+        port: transport
+      initialDelaySeconds: 60
+      periodSeconds: 10
+    nodeSelector: {}
+    podAnnotations: {}
+
+  client:
+    enabled: true
+    service:
+      type: ClusterIP
+      annotations: {}
+        # # Defined ELB backend protocol as HTTPS to allow connection to Elasticsearch API
+        # service.beta.kubernetes.io/aws-load-balancer-backend-protocol: https
+
+        # # ARN of ACM certificate registered to the deployed ELB for handling connections over TLS
+        # # ACM certificate should be issued to the DNS hostname defined earlier (elk.sec.example.com)
+        # service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "arn:aws:acm:us-east-1:111222333444:certificate/c69f6022-b24f-43d9-b9c8-dfe288d9443d"
+        # service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "https"
+
+        # service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
+        # service.beta.kubernetes.io/aws-load-balancer-connection-draining-timeout: "60"
+        # service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+
+        # # Annotation to create internal only ELB
+        # service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+    replicas: 2
+    javaOpts: "-Xms512m -Xmx512m"
+    nodeAffinity: {}
+    ingress:
+      enabled: true
+      annotations: {}
+        # kubernetes.io/ingress.class: nginx
+        # kubernetes.io/tls-acme: "true"
+      labels: {}
+      path: /
+      hosts:
+        - chart-example.local
+      tls: []
+      #  - secretName: chart-example-tls
+      #    hosts:
+      #      - chart-example.local
+    resources:
+      limits:
+        cpu: 1
+        memory: 1024Mi
+      requests:
+        cpu: 200m
+        memory: 1024Mi
+    podDisruptionBudget:
+      enabled: false
+      minAvailable: 1
+    tolerations: []
+    readinessProbe: []
+    livenessProbe:
+      tcpSocket:
+        port: transport
+      initialDelaySeconds: 60
+      periodSeconds: 10
+    nodeSelector: {}
+    podAnnotations: {}
+
+  config: {}
+    ## Example Config
+    # opendistro_security.allow_unsafe_democertificates: false
+    # opendistro_security.allow_default_init_securityindex: true
+    # opendistro_security.audit.type: internal_elasticsearch
+    # opendistro_security.enable_snapshot_restore_privilege: true
+    # opendistro_security.check_snapshot_restore_write_privileges: true
+    # cluster.routing.allocation.disk.threshold_enabled: false
+    # opendistro_security.audit.config.disabled_rest_categories: NONE
+    # opendistro_security.audit.config.disabled_transport_categories: NONE
+    # cluster:
+    #   name: ${CLUSTER_NAME}
+    # node:
+    #   master: ${NODE_MASTER}
+    #   data: ${NODE_DATA}
+    #   name: ${NODE_NAME}
+    #   ingest: ${NODE_INGEST}
+    #   max_local_storage_nodes: 1
+    #   attr.box_type: hot
+
+    # processors: ${PROCESSORS:1}
+
+    # network.host: ${NETWORK_HOST}
+
+    # thread_pool.bulk.queue_size: 800
+
+    # path:
+    #   data: /usr/share/elasticsearch/data
+    #   logs: /usr/share/elasticsearch/logs
+
+    # http:
+    #   enabled: ${HTTP_ENABLE}
+    #   compression: true
+
+    # discovery:
+    #   zen:
+    #     ping.unicast.hosts: ${DISCOVERY_SERVICE}
+    #     minimum_master_nodes: ${NUMBER_OF_MASTERS}
+
+    # # TLS Configuration Transport Layer
+    # opendistro_security.ssl.transport.pemcert_filepath: elk-transport-crt.pem
+    # opendistro_security.ssl.transport.pemkey_filepath: elk-transport-key.pem
+    # opendistro_security.ssl.transport.pemtrustedcas_filepath: elk-transport-root-ca.pem
+    # opendistro_security.ssl.transport.enforce_hostname_verification: false
+
+    # # TLS Configuration REST Layer
+    # opendistro_security.ssl.http.enabled: true
+    # opendistro_security.ssl.http.pemcert_filepath: elk-rest-crt.pem
+    # opendistro_security.ssl.http.pemkey_filepath: elk-rest-key.pem
+    # opendistro_security.ssl.http.pemtrustedcas_filepath: elk-rest-root-ca.pem
+
+  log4jConfig: ""
+
+  loggingConfig:
+    ## Default config
+    # you can override this using by setting a system property, for example -Des.logger.level=DEBUG
+    es.logger.level: INFO
+    rootLogger: ${es.logger.level}, console
+    logger:
+      # log action execution errors for easier debugging
+      action: DEBUG
+      # reduce the logging for aws, too much is logged under the default INFO
+      com.amazonaws: WARN
+    appender:
+      console:
+        type: console
+        layout:
+          type: consolePattern
+          conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+
+  transportKeyPassphrase:
+    enabled: false
+    passPhrase:
+
+  sslKeyPassphrase:
+    enabled: false
+    passPhrase:
+
+  maxMapCount: 262144
+
+  image: amazon/opendistro-for-elasticsearch
+  imageTag: 1.2.0
+
+  configDirectory: /usr/share/elasticsearch/config
+
+  serviceAccount:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    # The name of the ServiceAccount to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name:
+
+
+nameOverride: ""
+fullnameOverride: ""

--- a/deployments/logging/requirements.yaml
+++ b/deployments/logging/requirements.yaml
@@ -1,0 +1,6 @@
+dependencies:
+- name: opendistro-es
+  version: "1.1.0"
+- name: fluentd-elasticsearch
+  version: ">=3.0.0"
+  repository: https://kiwigrid.github.io

--- a/deployments/logging/values.yaml
+++ b/deployments/logging/values.yaml
@@ -1,0 +1,89 @@
+opendistro-es:
+  elasticsearch:
+    master:
+      storageClassName: standard
+    imageTag: 1.2.0
+    data:
+      storageClassName: standard
+
+  kibana:
+    imageTag: 1.2.0
+    ingress:
+      enabled: false
+
+fluentd-elasticsearch:
+  elasticsearch:
+    host: logging-opendistro-es-client-service
+    scheme: https
+    sslVerify: false
+    auth:
+      enabled: true
+      user: admin
+      password: admin
+    configMaps:
+      useDefaults:
+        containersInputConf: false
+    extraConfigMaps:
+      kubernetes.input.conf: |-
+        <source>
+          @id fluentd-containers.log
+          @type tail
+          path /var/log/containers/*.log
+          pos_file /var/log/containers.log.pos
+          tag raw.kubernetes.*
+          read_from_head true
+          <parse>
+            @type multi_format
+            <pattern>
+              format json
+              time_key time
+              time_format %Y-%m-%dT%H:%M:%S.%NZ
+            </pattern>
+            <pattern>
+              format /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
+              time_format %Y-%m-%dT%H:%M:%S.%N%:z
+            </pattern>
+          </parse>
+        </source>
+        # Detect exceptions in the log output and forward them as one log entry.
+        <match raw.kubernetes.**>
+          @id raw.kubernetes
+          @type detect_exceptions
+          remove_tag_prefix raw
+          message log
+          stream stream
+          multiline_flush_interval 5
+          max_bytes 500000
+          max_lines 1000
+        </match>
+        # Concatenate multi-line logs
+        #<filter **>
+        <filter kubernetes.**>
+          @id filter_concat
+          @type concat
+          key message
+          multiline_end_regexp /\n$/
+          separator ""
+        </filter>
+        # Enriches records with Kubernetes metadata
+        <filter kubernetes.**>
+          @id filter_kubernetes_metadata
+          @type kubernetes_metadata
+        </filter>
+        # Fixes json fields in Elasticsearch
+        <filter kubernetes.**>
+          @id filter_parser
+          @type parser
+          key_name log
+          reserve_data true
+          remove_key_name_field true
+          <parse>
+            @type multi_format
+            <pattern>
+              format json
+            </pattern>
+            <pattern>
+              format none
+            </pattern>
+          </parse>
+        </filter>

--- a/deployments/roundtable/resources/logging.yaml
+++ b/deployments/roundtable/resources/logging.yaml
@@ -11,9 +11,6 @@ spec:
     server: https://kubernetes.default.svc
   project: default
   source:
-    path: services/logging
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    path: deployments/logging
+    repoURL: https://github.com/lsst-sqre/roundtable.git
     targetRevision: HEAD
-    helm:
-      valueFiles:
-      - values-roundtable.yaml


### PR DESCRIPTION
Okay go from the LSP way to using the opendistro-es chart.  I'm copying
in version 1.1, and it comes from here:

https://github.com/opendistro-for-elasticsearch/community/tree/master/open-distro-elasticsearch-kubernetes/helm

Copied at hash:

710e8e022595a8f3c0a7897eadf46074d0a03808

This is because they don't seem to publish this chart over the normal Helm HTTP way.