### PR TITLE
For Argo CD RBAC, use correct GitHub team

### DIFF
--- a/deployments/argo-cd/patches/argocd-rbac-cm.yaml
+++ b/deployments/argo-cd/patches/argocd-rbac-cm.yaml
@@ -7,4 +7,4 @@ data:
   policy.default: role:readonly
   # Make members of the lsst-sqre/roundtable-ops team administrators
   policy.csv: |
-      g, lsst-sqre:roundtable-ops, role:admin
+      g, lsst-sqre:Roundtable Ops, role:admin


### PR DESCRIPTION
Rather than using the URL form of the GitHub team name, use the
display name.  This appears to be what the built-in Dex SSO in
Argo CD expects based on experience with the EFD cluster.