### PR TITLE
[DM-23532] Fix Argo CD health checks on ingress

### DIFF
--- a/deployments/nginx-ingress/values.yaml
+++ b/deployments/nginx-ingress/values.yaml
@@ -6,6 +6,8 @@ nginx-ingress:
       enabled: true
       service:
         clusterIP: "10.4.46.235"
+    publishService:
+      enabled: true
     service:
       clusterIP: "10.4.40.37"
   defaultBackend:


### PR DESCRIPTION
The Argo CD health check for an ingress waits for the
status.loadBalancer.ingress list to be updated, but the nginx
ingress controller does not do that by default.

Set the flag in its configuration that tells it to publish the
service information to the ingress, hopefully fixing this issue.

See the Argo CD FAQ at:
https://github.com/argoproj/argo-cd/blob/master/docs/faq.md