### PR TITLE
[DM-23507] Rename ghslacker to checkerboard

### DIFF
--- a/deployments/app-land/kustomization.yaml
+++ b/deployments/app-land/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
   # Namespaces
   - resources/lsst-the-docs-ns.yaml
   # Applications
-  - resources/ghslacker.yaml
+  - resources/checkerboard.yaml
   - resources/lsst-the-docs.yaml
   - resources/sqrbot-jr.yaml
   - resources/sqrbot-jsick.yaml

--- a/deployments/app-land/resources/checkerboard.yaml
+++ b/deployments/app-land/resources/checkerboard.yaml
@@ -1,14 +1,14 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: ghslacker
+  name: checkerboard
 spec:
   destination:
     namespace: events
     server: https://kubernetes.default.svc
   project: default
   source:
-    path: deployments/ghslacker
+    path: deployments/checkerboard
     repoURL: https://github.com/lsst-sqre/roundtable
     targetRevision: HEAD
   syncPolicy:

--- a/deployments/app-land/resources/roundtable-ingress.yaml
+++ b/deployments/app-land/resources/roundtable-ingress.yaml
@@ -15,9 +15,9 @@ spec:
     - host: roundtable.lsst.codes
       http:
         paths:
-          - path: /ghslacker
+          - path: /checkerboard
             backend:
-              serviceName: ghslacker
+              serviceName: checkerboard
               servicePort: 5000
           - path: /sqrbot-jr
             backend:

--- a/deployments/argo-cd/patches/argocd-cm.yaml
+++ b/deployments/argo-cd/patches/argocd-cm.yaml
@@ -23,15 +23,16 @@ data:
   # Git repositories that Argo CD monitors.
   repositories: |
     - url: https://github.com/argoproj/argocd-example-apps.git
-    - url: https://github.com/lsst-sqre/roundtable.git
     - url: https://github.com/argoproj/argo-cd.git
-    - url: https://github.com/lsst-sqre/ltd-keeper.git
+    - url: https://github.com/lsst-sqre/checkerboard.git
+    - url: https://github.com/lsst-sqre/lsp-deploy.git
+    - url: https://github.com/lsst-sqre/lsst-templatebot-aide.git
     - url: https://github.com/lsst-sqre/ltd-dasher.git
+    - url: https://github.com/lsst-sqre/ltd-keeper.git
+    - url: https://github.com/lsst-sqre/roundtable.git
     - url: https://github.com/lsst-sqre/sqrbot-jr.git
     - url: https://github.com/lsst-sqre/strimzi-registry-operator.git
     - url: https://github.com/lsst-sqre/templatebot.git
-    - url: https://github.com/lsst-sqre/lsst-templatebot-aide.git
-    - url: https://github.com/lsst-sqre/lsp-deploy.git
   # Non-standard Helm chart repositories.
   helm.repositories: |
     # For the cert-manager chart

--- a/deployments/checkerboard/README.md
+++ b/deployments/checkerboard/README.md
@@ -1,0 +1,5 @@
+# checkerboard
+
+- Status: ![](https://cd.roundtable.lsst.codes/api/badge?name=checkerboard)
+- Dashboard: https://cd.roundtable.lsst.codes/applications/checkerboard
+- Docs: https://github.com/lsst-sqre/checkerboard

--- a/deployments/checkerboard/kustomization.yaml
+++ b/deployments/checkerboard/kustomization.yaml
@@ -4,5 +4,5 @@ kind: Kustomization
 namespace: events
 
 resources:
-  - github.com/lsst-sqre/uservice-ghslacker.git//manifests/base?ref=0.1.1
+  - github.com/lsst-sqre/checkerboard.git//manifests/base?ref=0.2.0
   - resources/secret.yaml

--- a/deployments/checkerboard/resources/secret.yaml
+++ b/deployments/checkerboard/resources/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: checkerboard
+  namespace: events
+spec:
+  path: secret/k8s_operator/roundtable/dm/square/checkerboard
+  type: Opaque

--- a/deployments/ghslacker/README.md
+++ b/deployments/ghslacker/README.md
@@ -1,5 +1,0 @@
-# ghslacker
-
-- Status: ![](https://cd.roundtable.lsst.codes/api/badge?name=ghslacker)
-- Dashboard: https://cd.roundtable.lsst.codes/applications/ghslacker
-- Docs: https://github.com/lsst-sqre/uservice-ghslacker

--- a/deployments/ghslacker/resources/secret.yaml
+++ b/deployments/ghslacker/resources/secret.yaml
@@ -1,8 +1,0 @@
-apiVersion: ricoberger.de/v1alpha1
-kind: VaultSecret
-metadata:
-  name: ghslacker
-  namespace: ghslacker
-spec:
-  path: secret/k8s_operator/roundtable/dm/square/ghslacker
-  type: Opaque

--- a/docs/app-guide/ingress.rst
+++ b/docs/app-guide/ingress.rst
@@ -67,7 +67,7 @@ Using a route
 =============
 
 Giving your application a route on ``roundtable.lsst.codes`` is most appropriate for small :abbr:`SOA (Service-Oriented Architecture)` services that provide an API rather than a web site.
-Examples of applications like this are ghslacker and sqrbot-jr.
+Examples of applications like this are checkerboard and sqrbot-jr.
 In this case, add the route for the application to the shared ingress defined in ``deployments/app-land/resources/roundtable-ingress.yaml``.
 
 This ingress defines the ``roundtable.lsst.codes`` host and its routes.


### PR DESCRIPTION
Also adds missing Git repository monitoring for Argo CD and sorts that list.