### PR TITLE
DM-23899: Add Kafka User and Topic for LTD Events

### DIFF
--- a/deployments/events/kustomization.yaml
+++ b/deployments/events/kustomization.yaml
@@ -13,11 +13,13 @@ resources:
   - resources/templatebot-topics.yaml
   - resources/sqrbot-jsick-topics.yaml
   - resources/templatebot-jsick-topics.yaml
+  - resources/ltdevents-topics.yaml
   # Kafka users
   - resources/demo-user.yaml
   - resources/sqrbot-jr-user.yaml
   - resources/templatebot-user.yaml
   - resources/sqrbot-jsick-user.yaml
   - resources/templatebot-jsick-user.yaml
+  - resources/ltdevents-user.yaml
 
 namespace: events

--- a/deployments/events/resources/ltdevents-topics.yaml
+++ b/deployments/events/resources/ltdevents-topics.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaTopic
+metadata:
+  name: "ltd.events"
+  labels:
+    strimzi.io/cluster: events
+spec:
+  partitions: 8
+  replicas: 3
+  config:
+    # http://kafka.apache.org/documentation/#topicconfigs
+    retention.ms: 2592000000 # 30 days

--- a/deployments/events/resources/ltdevents-user.yaml
+++ b/deployments/events/resources/ltdevents-user.yaml
@@ -1,0 +1,25 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaUser
+metadata:
+  name: kafkauser-ltdevents
+  labels:
+    strimzi.io/cluster: events
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      # Produce ltd.events
+      - resource:
+          type: topic
+          name: "ltd.events"
+          patternType: literal
+        operation: "Write"
+        type: allow
+      - resource:
+          type: topic
+          name: "ltd.events"
+          patternType: literal
+        operation: "Describe"
+        type: allow


### PR DESCRIPTION
These updates are for the future deployment of LTD Events (https://github.com/lsst-sqre/ltd-events):

- `ltd.events topic` is what LTD Events produces to (different types of events are multiplexed). It has a long retention so that we can effectively keep a log of documentation update activity.

- `ltdevents` Kafka user that produces messages to the ltd.events topic. At the moment this user doesn't consume any topics, but it's conceivable that it'll consume GitHub topics in the future.