### PR TITLE
DM-23731: Initial deployment of ltd events application

### DIFF
--- a/deployments/app-land/kustomization.yaml
+++ b/deployments/app-land/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   # Applications
   - resources/checkerboard.yaml
   - resources/lsst-the-docs.yaml
+  - resources/ltdevents.yaml
   - resources/safirdemo.yaml
   - resources/sqrbot-jr.yaml
   - resources/sqrbot-jsick.yaml

--- a/deployments/app-land/resources/ltdevents.yaml
+++ b/deployments/app-land/resources/ltdevents.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ltdevents
+spec:
+  destination:
+    namespace: events
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: deployments/ltdevents
+    repoURL: https://github.com/lsst-sqre/roundtable
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true

--- a/deployments/app-land/resources/roundtable-ingress.yaml
+++ b/deployments/app-land/resources/roundtable-ingress.yaml
@@ -19,6 +19,10 @@ spec:
             backend:
               serviceName: checkerboard
               servicePort: 8080
+          - path: /ltdevents
+            backend:
+              serviceName: ltdevents
+              servicePort: 8080
           - path: /safirdemo
             backend:
               serviceName: safirdemo

--- a/deployments/argo-cd/patches/argocd-cm.yaml
+++ b/deployments/argo-cd/patches/argocd-cm.yaml
@@ -28,6 +28,7 @@ data:
     - url: https://github.com/lsst-sqre/lsp-deploy.git
     - url: https://github.com/lsst-sqre/lsst-templatebot-aide.git
     - url: https://github.com/lsst-sqre/ltd-dasher.git
+    - url: https://github.com/lsst-sqre/ltd-events.git
     - url: https://github.com/lsst-sqre/ltd-keeper.git
     - url: https://github.com/lsst-sqre/roundtable.git
     - url: https://github.com/lsst-sqre/safirdemo.git

--- a/deployments/ltdevents/README.md
+++ b/deployments/ltdevents/README.md
@@ -1,0 +1,5 @@
+# ltdevents
+
+- Status: ![](https://cd.roundtable.lsst.codes/api/badge?name=ltdevents)
+- Dashboard: https://cd.roundtable.lsst.codes/applications/ltdevents
+- Docs: https://github.com/lsst-sqre/ltd-events

--- a/deployments/ltdevents/kustomization.yaml
+++ b/deployments/ltdevents/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: events
+
+images:
+  - name: "lsstsqre/ltdevents"
+    newTag: "tickets-DM-23731"
+
+resources:
+  - github.com/lsst-sqre/ltd-events.git//manifests/base?ref=tickets/DM-23731
+
+patches:
+  - patches/configmap.yaml
+  - patches/deployment.yaml

--- a/deployments/ltdevents/patches/configmap.yaml
+++ b/deployments/ltdevents/patches/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ltdevents
+data:
+  SAFIR_NAME: "ltdevents"
+  SAFIR_PROFILE: "production"
+  SAFIR_LOG_LEVEL: "INFO"
+  SAFIR_KAFKA_PROTOCOL: "SSL"
+  SAFIR_KAFKA_BROKER_URL: "events-kafka-bootstrap:9093"
+  SAFIR_KAFKA_CLUSTER_CA: "/var/strimzi-broker/ca.crt"
+  SAFIR_KAFKA_CLIENT_CA: "/var/strimzi-client/ca.crt"
+  SAFIR_KAFKA_CLIENT_CERT: "/var/strimzi-client/user.crt"
+  SAFIR_KAFKA_CLIENT_KEY: "/var/strimzi-client/user.key"
+  SAFIR_SCHEMA_REGISTRY_URL: "http://schemaregistry:8081"
+  SAFIR_SCHEMA_SUFFIX: ""
+  SAFIR_SCHEMA_COMPATIBILITY: "FORWARD"
+  LTD_EVENTS_KAFKA_TOPIC: "ltd.events"

--- a/deployments/ltdevents/patches/deployment.yaml
+++ b/deployments/ltdevents/patches/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ltdevents
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: app
+          volumeMounts:
+            - name: "client-tls"
+              mountPath: "/var/strimzi-client"
+              readOnly: True
+            - name: "broker-tls"
+              mountPath: "/var/strimzi-broker"
+              readOnly: True
+      volumes:
+        # Mount the TLS secret created by KafkaUser
+        - name: "client-tls"
+          secret:
+            secretName: kafkauser-ltdevents  # matches name of KafkaUser
+        - name: "broker-tls"
+          secret:
+            secretName: "events-cluster-ca-cert" # matches name of Strimzi cluster cluster CA cert secret


### PR DESCRIPTION
This PR adds the ltdevents application (available at a `/ltdevents/` external endpoint). The application is tracking the `tickets/DM-23731` branch of https://github.com/lsst-sqre/ltd-events (https://github.com/lsst-sqre/ltd-events/pull/1).