### PR TITLE
DM-23899: Deploy LTD Keeper with LTD Events integration

### DIFF
--- a/deployments/lsst-the-docs/kustomization.yaml
+++ b/deployments/lsst-the-docs/kustomization.yaml
@@ -8,6 +8,9 @@ resources:
 - resources/keeper-ingress.yaml
 - github.com/lsst-sqre/ltd-dasher.git//manifests?ref=0.1.4
 
+patches:
+  - patches/keeper-deployment.yaml
+
 namespace: lsst-the-docs
 
 images:

--- a/deployments/lsst-the-docs/kustomization.yaml
+++ b/deployments/lsst-the-docs/kustomization.yaml
@@ -4,8 +4,12 @@ kind: Kustomization
 resources:
 - resources/keeper-sealedsecret.yaml
 - resources/cloudsql-sealedsecret.yaml
-- github.com/lsst-sqre/ltd-keeper.git//manifests?ref=1.17.0
+- github.com/lsst-sqre/ltd-keeper.git//manifests?ref=tickets/DM-23899
 - resources/keeper-ingress.yaml
 - github.com/lsst-sqre/ltd-dasher.git//manifests?ref=0.1.4
 
 namespace: lsst-the-docs
+
+images:
+  - name: lsstsqre/ltd-keeper
+    newTag: tickets-DM-23899

--- a/deployments/lsst-the-docs/patches/keeper-deployment.yaml
+++ b/deployments/lsst-the-docs/patches/keeper-deployment.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keeper-api
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          env:
+            - name: LTD_EVENTS_URL
+              value: "http://ltdevents.events:8080/webhook"
+
+---
+# Deployment of celery workers for keeper
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keeper-worker-deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          env:
+            - name: LTD_EVENTS_URL
+              value: "http://ltdevents.events:8080/webhook"

--- a/deployments/ltdevents/patches/configmap.yaml
+++ b/deployments/ltdevents/patches/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   SAFIR_NAME: "ltdevents"
   SAFIR_PROFILE: "production"
-  SAFIR_LOG_LEVEL: "INFO"
+  SAFIR_LOG_LEVEL: "DEBUG"
   SAFIR_KAFKA_PROTOCOL: "SSL"
   SAFIR_KAFKA_BROKER_URL: "events-kafka-bootstrap:9093"
   SAFIR_KAFKA_CLUSTER_CA: "/var/strimzi-broker/ca.crt"


### PR DESCRIPTION
This version of LTD Keeper posts `ltd.updated` webhook payloads to the `http://ltdevents.events:8080/webhook` internal endpoint of the `ltdevents` app.