### PR TITLE
[DM-23546] Update apiVersion for Ingress resources

### DIFF
--- a/deployments/app-land/resources/roundtable-ingress.yaml
+++ b/deployments/app-land/resources/roundtable-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: roundtable-ingress

--- a/deployments/argo-cd/resources/argocd-grpc-ingress.yaml
+++ b/deployments/argo-cd/resources/argocd-grpc-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: argocd-grpc

--- a/deployments/argo-cd/resources/argocd-ui-ingress.yaml
+++ b/deployments/argo-cd/resources/argocd-ui-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: argocd-ui

--- a/deployments/logging/requirements.yaml
+++ b/deployments/logging/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: opendistro-es
-  version: "1.1.0"
+  version: "1.4.0"
   repository: https://lsst-sqre.github.io/charts/
 - name: fluentd-elasticsearch
   version: ">=3.0.0"

--- a/deployments/lsst-the-docs/resources/keeper-ingress.yaml
+++ b/deployments/lsst-the-docs/resources/keeper-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: keeper

--- a/deployments/prometheus/templates/grafana-ingress.yaml
+++ b/deployments/prometheus/templates/grafana-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: grafana

--- a/docs/app-guide/ingress.rst
+++ b/docs/app-guide/ingress.rst
@@ -19,7 +19,7 @@ That ingress definition should look something like this:
 
 .. code-block:: yaml
 
-   apiVersion: extensions/v1beta1
+   apiVersion: networking.k8s.io/v1beta1
    kind: Ingress
    metadata:
      name: <app-name>

--- a/docs/ops/argo-cd/argocd-github-sso.rst
+++ b/docs/ops/argo-cd/argocd-github-sso.rst
@@ -26,5 +26,5 @@ Currently only members of the `lsst-sqre GitHub organization`_ can log in.
 Dex, the OIDC component used by Argo CD, also supports limited access by GitHub team.
 See the `Authenticating with GitHub page <https://github.com/dexidp/dex/blob/master/Documentation/connectors/github.md>`__ in the Dex documentation.
 
-.. _`SSO Configuration`: https://argoproj.github.io/argo-cd/operator-manual/sso/
+.. _`SSO Configuration`: https://argoproj.github.io/argo-cd/operator-manual/user-management/#sso
 .. _`argocd-cm.yaml patch`: https://github.com/lsst-sqre/roundtable/blob/master/deployments/argo-cd/patches/argocd-cm.yaml


### PR DESCRIPTION
Kubernetes 1.22 will drop support for defining Ingress resources
with the extensions/v1beta1 apiVersion.  Switch all of them to
networking.k8s.io/v1beta1, supported since 1.14.