### PR TITLE
[DM-23546] Remove pinning of opendistro-es images

### DIFF
--- a/deployments/logging/values.yaml
+++ b/deployments/logging/values.yaml
@@ -2,7 +2,6 @@ opendistro-es:
   elasticsearch:
     master:
       storageClassName: standard
-    imageTag: 1.3.0
     data:
       storageClassName: standard
     client:
@@ -10,7 +9,6 @@ opendistro-es:
         enabled: false
 
   kibana:
-    imageTag: 1.3.0
     ingress:
       enabled: false
 


### PR DESCRIPTION
The Helm chart sets these to an appropriate value.  Don't pin to a
version or we end up stuck on an older version when upgrading.