### PR TITLE
[DM-23546] Restore Elasticsearch replica count

### DIFF
--- a/deployments/logging/values.yaml
+++ b/deployments/logging/values.yaml
@@ -1,10 +1,13 @@
 opendistro-es:
   elasticsearch:
     master:
+      replicas: 3
       storageClassName: standard
     data:
+      replicas: 3
       storageClassName: standard
     client:
+      replicas: 2
       ingress:
         enabled: false
 


### PR DESCRIPTION
The new Helm chart reduces the replicas to 1 for all the components,
which is causing the master to decline to start.  Increase the
replica count to 3 for the master and data servers and 2 for the
client to match the previous configuration.