### PR TITLE
DM-23918: Add user and ops docs for the logging service

### DIFF
--- a/deployments/logging/README.md
+++ b/deployments/logging/README.md
@@ -1,0 +1,5 @@
+# logging
+
+- Status: ![](https://cd.roundtable.lsst.codes/api/badge?name=logging)
+- Dashboard: https://cd.roundtable.lsst.codes/applications/logging
+- Docs: https://roundtable.lsst.io/ops/logging

--- a/deployments/nginx-ingress/README.md
+++ b/deployments/nginx-ingress/README.md
@@ -1,5 +1,5 @@
 # nginx-ingress
 
-- Status: ![](https://cd.nginx-ingress.lsst.codes/api/badge?name=nginx-ingress)
+- Status: ![](https://cd.roundtable.lsst.codes/api/badge?name=nginx-ingress)
 - Dashboard: https://cd.roundtable.lsst.codes/applications/nginx-ingress
 - Docs: https://roundtable.lsst.io/ops/nginx-ingress

--- a/docs/app-guide/index.rst
+++ b/docs/app-guide/index.rst
@@ -6,4 +6,5 @@ Application developer guide
    :maxdepth: 2
 
    ingress
+   viewing-logs
    using-sealed-secrets

--- a/docs/app-guide/viewing-logs.rst
+++ b/docs/app-guide/viewing-logs.rst
@@ -1,0 +1,87 @@
+########################
+Viewing logs with Kibana
+########################
+
+Roundtable includes its own logging infrastructure.
+Your application's log messages to stdout and stderr are automatically captured by fluentd, stored in ElasticSearch, and made available with Kibana.
+This page will help you use Kibana to view your app's log messages.
+
+.. note::
+
+   To follow this tutorial, you will need kubectl access to the Roundtable cluster.
+   See :doc:`/ops/gke/howto-connect-to-gke`.
+
+Step 1: Port forward into the Kibana pod
+========================================
+
+Kibana is the front-end for viewing your logs.
+Currently, Kibana does not have a public URL.
+To access Kibana, you'll need to set up port forwarding between the Kibana pod in Roundtable and your localhost.
+Copy this line and run it in a terminal:
+
+.. code-block:: bash
+
+   kubectl -n logging port-forward `kubectl -n logging get pods -l app=logging-opendistro-es -l role=kibana -o name | head -n 1` 5601:5601
+
+Step 2: Log into Kibana
+=======================
+
+1. Open http://localhost:5601 in your browser.
+
+2. Enter the credentials:
+
+   Username
+     ``admin``
+
+   Password
+     ``admin``
+
+Step 3: Explore with the Discover tab
+=====================================
+
+The best place to start exploring log messages is in the Discover tab: http://localhost:5601/app/kibana#/discover.
+
+By default you can see every log message from across the entire Roundtable cluster.
+Here are a few tips to help filter the log stream down to just the messages you're interested in:
+
+- **You can filter messages based on the values you see.**
+  To do that, mouse over the log messages.
+  A magnifying glass appears:
+
+  - **If the message has a value you're interested in,** click the magnifying glass with a "+" symbol inside it.
+    Now only messages containing that value are shown.
+
+  - **If the message is one you're not interested in,** click the magnifying glass with a "-" symbol inside it.
+    Now messages containing that value aren't shown.
+
+- **Create filters based on Kubernetes labels.**
+  For example, a partial pod resource might look like this:
+
+  .. code-block:: yaml
+
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      labels:
+        name: myapp
+
+  You can select log messages this pod, and ones like it in a Deployment, based on the ``name: myapp`` label:
+
+  1. Click on the **+ Add filter** button, located below the search bar.
+
+  2. For **field,** enter ``kubernetes.labels.name`` (change as appropriate for the label).
+
+  3. For **operator,** select "``is``."
+     Alternatively, "``is in``" is useful for combining multiple log sources together.
+
+  4. For **value,** enter the value of the label (``myapp``, in this example).
+
+- **Create filters based on Kubernetes namespaces** using the field ``kubernetes.namespace_name``, following the same technique as above.
+
+- **Enter a plain text search.**
+  If you're looking for something specific, type it into the search box.
+
+Learning more
+=============
+
+The official `Kibana Guide <https://www.elastic.co/guide/en/kibana/current/index.html>`__ is a great resource for learning more about Kibana.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -132,6 +132,12 @@ rst_epilog = """
    :target: https://cd.roundtable.lsst.codes/applications/vault-secrets-operator
    :alt: Vault Secrets Operator app status
 
+.. |logging-status| image:: https://cd.roundtable.lsst.codes/api/badge?name=logging
+   :target: https://cd.roundtable.lsst.codes/applications/logging
+   :alt: Logging app status
+
+.. _Elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
+.. _Kibana: https://www.elastic.co/guide/en/kibana/current/index.html
 .. _Helm: https://helm.sh
 .. _Kustomize: https://kustomize.io
 .. _Argo CD: https://argoproj.github.io/argo-cd/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -157,7 +157,8 @@ linkcheck_ignore = [
     r'^https://monitoring.roundtable.lsst.codes',
     r'^https://github.com/organizations/lsst-sqre/settings/',
     r'^https://github.com/lsst-sqre/roundtable/settings/',
-    r'^https://github.com/bitnami-labs/sealed-secrets/blob/master/README\.md#homebrew$'
+    r'^https://github.com/bitnami-labs/sealed-secrets/blob/master/README\.md#homebrew$',
+    r'^http://localhost',
 ]
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/ops/index.rst
+++ b/docs/ops/index.rst
@@ -21,3 +21,4 @@ Although this documentation is openly available, application developers shouldn'
    sealed-secrets/index
    vault/index
    vault-secrets-operator/index
+   logging/index

--- a/docs/ops/logging/index.rst
+++ b/docs/ops/logging/index.rst
@@ -1,0 +1,29 @@
+############################
+logging app deployment guide
+############################
+
+.. list-table::
+   :widths: 10,40
+
+   * - Deployment
+     - |logging-status|
+   * - Edit on GitHub
+     - `/deployments/logging <https://github.com/lsst-sqre/roundtable/tree/master/deployments/logging>`__
+   * - Type
+     - Helm_
+   * - Parent app
+     - :doc:`roundtable <../roundtable/index>`
+
+.. rubric:: Overview
+
+The logging app is a self-contained system for gathering, storing, and visualizing logs from the Roundtable Kubernetes cluster.
+Kubernetes logs, as well as application logs emitted on stdout and stderr, are automatically gathered by the logging app.
+
+The logging app is built primarily around the ``opendistro-es`` chart maintained in https://github.com/lsst-sqre/charts.
+This chart provides Elasticsearch_ and Kibana_ services.
+The logging app also includes a ``fluentd-elasticsearch`` chart maintained in https://github.com/kiwigrid/helm-charts.
+Fluentd gathers logs.
+
+.. seealso::
+
+   :doc:`/app-guide/viewing-logs` explains how to log into the Kibana UI.


### PR DESCRIPTION
This PR is to add some documentation coverage for the logging service in Roundtable:

- User doc: https://roundtable.lsst.io/v/DM-23918/app-guide/viewing-logs.html
- Ops doc: https://roundtable.lsst.io/v/DM-23918/ops/logging/index.html
- README for the deployment