### PR TITLE
[DM-23546] Set the Kubernetes version for Prometheus

### DIFF
--- a/deployments/prometheus/values.yaml
+++ b/deployments/prometheus/values.yaml
@@ -1,4 +1,5 @@
 prometheus-operator:
+  kubeTargetVersionOverride: "1.15.9"
   prometheusOperator:
     admissionWebhooks:
       enabled: false


### PR DESCRIPTION
See if this causes it to install the default Grafana dashboards,
as implied by https://github.com/helm/charts/issues/16943.