### PR TITLE
DM-25234: Deploy LTD Dasher 0.1.6

### DIFF
--- a/deployments/lsst-the-docs/kustomization.yaml
+++ b/deployments/lsst-the-docs/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 - resources/cloudsql-sealedsecret.yaml
 - github.com/lsst-sqre/ltd-keeper.git//manifests?ref=master
 - resources/keeper-ingress.yaml
-- github.com/lsst-sqre/ltd-dasher.git//manifests?ref=0.1.4
+- github.com/lsst-sqre/ltd-dasher.git//manifests?ref=0.1.6
 
 patches:
   - patches/keeper-deployment.yaml


### PR DESCRIPTION
This updates the LTD Dasher deployment to omit Travis CI links from LSST the Docs dashboards.