### PR TITLE
DM-25233: Update templatebot-aide to 0.2.0

### DIFF
--- a/deployments/templatebot/kustomization.yaml
+++ b/deployments/templatebot/kustomization.yaml
@@ -7,10 +7,14 @@ resources:
   - resources/templatebot-sealedsecret.yaml
   - resources/templatebot-aide-sealedsecret.yaml
   - github.com/lsst-sqre/templatebot.git//manifests/base?ref=0.1.0
-  - github.com/lsst-sqre/lsst-templatebot-aide.git//manifests/base?ref=0.1.0
+  - github.com/lsst-sqre/lsst-templatebot-aide.git//manifests/base?ref=0.2.0
 
 patches:
   - patches/templatebot-configmap.yaml
   - patches/templatebot-deployment.yaml
   - patches/templatebot-aide-configmap.yaml
   - patches/templatebot-aide-deployment.yaml
+
+images:
+  - name: lsstsqre/templatebot-aide
+    newTag: 0.2.0

--- a/deployments/templatebot/patches/templatebot-aide-deployment.yaml
+++ b/deployments/templatebot/patches/templatebot-aide-deployment.yaml
@@ -15,7 +15,6 @@ spec:
     spec:
       containers:
         - name: templatebot-aide-app
-          image: lsstsqre/templatebot-aide:0.1.0
           env:
             - name: SLACK_TOKEN
               valueFrom:


### PR DESCRIPTION
This release works with GitHub Actions-based technote templates.

See https://github.com/lsst/templates/pull/80