### PR TITLE
DM-25331: Test DM-25331 version of templatebot-aide

### DIFF
--- a/deployments/templatebot/kustomization.yaml
+++ b/deployments/templatebot/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - resources/templatebot-sealedsecret.yaml
   - resources/templatebot-aide-sealedsecret.yaml
   - github.com/lsst-sqre/templatebot.git//manifests/base?ref=0.1.0
-  - github.com/lsst-sqre/lsst-templatebot-aide.git//manifests/base?ref=0.2.1
+  - github.com/lsst-sqre/lsst-templatebot-aide.git//manifests/base?ref=tickets/DM-25331
 
 patches:
   - patches/templatebot-configmap.yaml

--- a/deployments/templatebot/patches/templatebot-configmap.yaml
+++ b/deployments/templatebot/patches/templatebot-configmap.yaml
@@ -9,7 +9,7 @@ data:
   API_LSST_CODES_NAME: 'templatebot'
   API_LSST_CODES_PROFILE: "production"
   TEMPLATEBOT_REPO: "https://github.com/lsst/templates"
-  TEMPLATEBOT_REPO_REF: "master"
+  TEMPLATEBOT_REPO_REF: "tickets/DM-25331"
   # Feature flags
   TEMPLATEBOT_TOPIC_CONFIG: "0"
   TEMPLATEBOT_ENABLE_SLACK_CONSUMER: "1"


### PR DESCRIPTION
- Set templatebot to use the tickets/DM-25331 branch of lsst/templates to test the new test_report and latex_lsstdoc templates.
- Use tickets-DM-25331 version of templatebot-aide to get support for the test_report and latex_lsstdoc templates.