### PR TITLE
[DM-25183] Help automated upgrade detection

### DIFF
--- a/deployments/cert-manager/Chart.yaml
+++ b/deployments/cert-manager/Chart.yaml
@@ -1,1 +1,3 @@
+apiVersion: v1
 name: cert-manager
+version: 1.0.0

--- a/deployments/checkerboard/kustomization.yaml
+++ b/deployments/checkerboard/kustomization.yaml
@@ -4,5 +4,5 @@ kind: Kustomization
 namespace: events
 
 resources:
-  - github.com/lsst-sqre/checkerboard.git//manifests/base?ref=0.3.0
+  - "https://github.com/lsst-sqre/checkerboard//manifests/base?ref=0.3.0"
   - resources/secret.yaml

--- a/deployments/logging/Chart.yaml
+++ b/deployments/logging/Chart.yaml
@@ -1,2 +1,3 @@
+apiVersion: v1
 name: logging
 version: 0.0.1

--- a/deployments/nginx-ingress/Chart.yaml
+++ b/deployments/nginx-ingress/Chart.yaml
@@ -1,1 +1,3 @@
+apiVersion: v1
 name: nginx-ingress
+version: 1.0.0

--- a/deployments/prometheus/Chart.yaml
+++ b/deployments/prometheus/Chart.yaml
@@ -1,1 +1,3 @@
+apiVersion: v1
 name: prometheus
+version: 1.0.0

--- a/deployments/strimzi/Chart.yaml
+++ b/deployments/strimzi/Chart.yaml
@@ -1,1 +1,3 @@
+apiVersion: v1
 name: strimzi
+version: 1.0.0

--- a/deployments/vault-secrets-operator/Chart.yaml
+++ b/deployments/vault-secrets-operator/Chart.yaml
@@ -1,1 +1,3 @@
+apiVersion: v1
 name: vault-secrets-operator
+version: 1.0.0

--- a/deployments/vault/Chart.yaml
+++ b/deployments/vault/Chart.yaml
@@ -1,1 +1,3 @@
+apiVersion: v1
 name: vault
+version: 1.0.0

--- a/deployments/vault/requirements.yaml
+++ b/deployments/vault/requirements.yaml
@@ -1,3 +1,4 @@
 dependencies:
   - name: vault
     version: 0.3.3
+    repository: https://helm.releases.hashicorp.com


### PR DESCRIPTION
- Add the repository for the vault Helm chart
- Try a different format for the Kustomize resource URL to see if it fixes a renovatebot issue
- Add `apiVersion` and `version` to all stub Helm charts, since renovatebot won't analyze them otherwise