### PR TITLE
Revert "[DM-25183] Try different kustomize resource URL"

### DIFF
--- a/deployments/checkerboard/kustomization.yaml
+++ b/deployments/checkerboard/kustomization.yaml
@@ -4,5 +4,5 @@ kind: Kustomization
 namespace: events
 
 resources:
-  - "https://github.com/lsst-sqre/checkerboard//manifests/base?ref=0.3.0"
+  - github.com/lsst-sqre/checkerboard.git//manifests/base?ref=0.3.0
   - resources/secret.yaml


### PR DESCRIPTION
This reverts commit b01a1bf2a54a8d57a4692b89949c4226b191c4b6.
Renovate cannot cope with Kustomize GitHub URLs in either format.