### PR TITLE
DM-25331: Complete deployment of templatebot-aide for test_report and latex_lsstdoc templates

### DIFF
--- a/deployments/templatebot/kustomization.yaml
+++ b/deployments/templatebot/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - resources/templatebot-sealedsecret.yaml
   - resources/templatebot-aide-sealedsecret.yaml
   - github.com/lsst-sqre/templatebot.git//manifests/base?ref=0.1.0
-  - github.com/lsst-sqre/lsst-templatebot-aide.git//manifests/base?ref=tickets/DM-25331
+  - github.com/lsst-sqre/lsst-templatebot-aide.git//manifests/base?ref=0.3.0
 
 patches:
   - patches/templatebot-configmap.yaml

--- a/deployments/templatebot/patches/templatebot-configmap.yaml
+++ b/deployments/templatebot/patches/templatebot-configmap.yaml
@@ -9,7 +9,7 @@ data:
   API_LSST_CODES_NAME: 'templatebot'
   API_LSST_CODES_PROFILE: "production"
   TEMPLATEBOT_REPO: "https://github.com/lsst/templates"
-  TEMPLATEBOT_REPO_REF: "tickets/DM-25331"
+  TEMPLATEBOT_REPO_REF: "master"
   # Feature flags
   TEMPLATEBOT_TOPIC_CONFIG: "0"
   TEMPLATEBOT_ENABLE_SLACK_CONSUMER: "1"


### PR DESCRIPTION
- Updates templatebot configuration to point at lsst/templates's master branch since lsst/templates#86 is merged.
- Deploys lsst-templatbot-aide 0.3.0, which is the released version of the ticket branch that was previously deployed.