### PR TITLE
DM-25427: Remove templatebot image/tag from patch

### DIFF
--- a/deployments/templatebot/patches/templatebot-deployment.yaml
+++ b/deployments/templatebot/patches/templatebot-deployment.yaml
@@ -16,7 +16,6 @@ spec:
     spec:
       containers:
         - name: templatebot-app
-          image: lsstsqre/templatebot:0.1.0
           env:
             - name: TEMPLATEBOT_GITHUB_TOKEN
               valueFrom:


### PR DESCRIPTION
This was preventing the base manifest from successfully setting its own tag. It was probably originally done to override a tagging error in the 0.1.0 release.