### PR TITLE
DM-24958: Preliminary initial Ook deployment

### DIFF
--- a/deployments/app-land/kustomization.yaml
+++ b/deployments/app-land/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
   - resources/templatebot.yaml
   - resources/templatebot-jsick.yaml
   - resources/segwarides.yaml
+  - resources/ook.yaml

--- a/deployments/app-land/resources/ook.yaml
+++ b/deployments/app-land/resources/ook.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ook
+spec:
+  destination:
+    namespace: events
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: deployments/ook
+    repoURL: https://github.com/lsst-sqre/roundtable
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true

--- a/deployments/argo-cd/patches/argocd-cm.yaml
+++ b/deployments/argo-cd/patches/argocd-cm.yaml
@@ -35,6 +35,7 @@ data:
     - url: https://github.com/lsst-sqre/sqrbot-jr.git
     - url: https://github.com/lsst-sqre/strimzi-registry-operator.git
     - url: https://github.com/lsst-sqre/templatebot.git
+    - url: https://github.com/lsst-sqre/ook.git
   # Non-standard Helm chart repositories.
   helm.repositories: |
     # For the cert-manager chart

--- a/deployments/events/kustomization.yaml
+++ b/deployments/events/kustomization.yaml
@@ -22,5 +22,6 @@ resources:
   - resources/sqrbot-jsick-user.yaml
   - resources/templatebot-jsick-user.yaml
   - resources/ltdevents-user.yaml
+  - resources/ook-user.yaml
 
 namespace: events

--- a/deployments/events/kustomization.yaml
+++ b/deployments/events/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - resources/sqrbot-jsick-topics.yaml
   - resources/templatebot-jsick-topics.yaml
   - resources/ltdevents-topics.yaml
+  - resources/ook-topics.yaml
   # Kafka users
   - resources/demo-user.yaml
   - resources/sqrbot-jr-user.yaml

--- a/deployments/events/resources/ook-topics.yaml
+++ b/deployments/events/resources/ook-topics.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaTopic
+metadata:
+  name: "ook.ingest"
+  labels:
+    strimzi.io/cluster: events
+spec:
+  partitions: 16
+  replicas: 3
+  config:
+    # http://kafka.apache.org/documentation/#topicconfigs
+    retention.ms: 604800000 # 7 days

--- a/deployments/events/resources/ook-user.yaml
+++ b/deployments/events/resources/ook-user.yaml
@@ -1,0 +1,91 @@
+---
+# For the ook-queue consumer group
+# This user reads ltd.events and writes to ook.queue
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaUser
+metadata:
+  name: kafkauser-ook-queue
+  labels:
+    strimzi.io/cluster: events
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      # Produce ook.ingest
+      - resource:
+          type: topic
+          name: "ook.ingest"
+          patternType: literal
+        operation: "Write"
+        type: "allow"
+      - resource:
+          type: topic
+          name: "ook.ingest"
+          patternType: literal
+        operation: "Describe"
+        type: "allow"
+      # Access ook-queue consumer group
+      - resource:
+          type: "group"
+          name: "ook-queue"
+          patternType: "literal"
+        operation: "Describe"
+        type: "allow"
+      - resource:
+          type: "group"
+          name: "ook-queue"
+          patternType: "literal"
+      # Consume the ltd.events topic
+      - resource:
+          type: "topic"
+          name: "ltd.events"
+          patternType: "literal"
+        operation: "Read"
+        type: "allow"
+      - resource:
+          type: "topic"
+          name: "ltd.events"
+          patternType: "literal"
+        operation: "Describe"
+        type: "allow"
+---
+# For the ook-ingest consumer group
+# This user reads ook.queue
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaUser
+metadata:
+  name: kafkauser-ook-ingest
+  labels:
+    strimzi.io/cluster: events
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      # Access ook-ingest consumer group
+      - resource:
+          type: "group"
+          name: "ook-ingest"
+          patternType: "literal"
+        operation: "Describe"
+        type: "allow"
+      - resource:
+          type: "group"
+          name: "ook-ingest"
+          patternType: "literal"
+      # Consume the ook.ingest topic
+      - resource:
+          type: "topic"
+          name: "ook.ingest"
+          patternType: "literal"
+        operation: "Read"
+        type: "allow"
+      - resource:
+          type: "topic"
+          name: "ook.ingest"
+          patternType: "literal"
+        operation: "Describe"
+        type: "allow"

--- a/deployments/ook/README.md
+++ b/deployments/ook/README.md
@@ -1,0 +1,5 @@
+# ook
+
+- Status: ![](https://cd.roundtable.lsst.codes/api/badge?name=ook)
+- Dashboard: https://cd.roundtable.lsst.codes/applications/ook
+- Docs: https://github.com/lsst-sqre/ook

--- a/deployments/ook/kustomization.yaml
+++ b/deployments/ook/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: events
+
+resources:
+  - resources/vaultsecret.yaml
+  - github.com/lsst-sqre/ook.git//manifests/base?ref=tickets/DM-24958
+
+patches:
+  - patches/configmap.yaml
+  - patches/deployment.yaml

--- a/deployments/ook/patches/configmap.yaml
+++ b/deployments/ook/patches/configmap.yaml
@@ -1,0 +1,50 @@
+---
+# Configuration for the ook-queue deployment
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ook-queue
+data:
+  SAFIR_NAME: "ook"
+  SAFIR_PROFILE: "production"
+  SAFIR_LOGGER: "ook"
+  SAFIR_LOG_LEVEL: "INFO"
+  SAFIR_KAFKA_PROTOCOL: "SSL"
+  SAFIR_KAFKA_BROKER_URL: "events-kafka-bootstrap:9093"
+  SAFIR_KAFKA_CLUSTER_CA: "/var/strimzi-broker/ca.crt"
+  SAFIR_KAFKA_CLIENT_CA: "/var/strimzi-client/ca.crt"
+  SAFIR_KAFKA_CLIENT_CERT: "/var/strimzi-client/user.crt"
+  SAFIR_KAFKA_CLIENT_KEY: "/var/strimzi-client/user.key"
+  SAFIR_SCHEMA_REGISTRY_URL: "http://schemaregistry:8081"
+  SAFIR_SCHEMA_SUFFIX: ""
+  SAFIR_SCHEMA_COMPATIBILITY: "FORWARD_TRANSITIVE"
+  ENABLE_LTD_EVENTS_KAFKA_TOPIC: "true"
+  ENABLE_OOK_INGEST_KAFKA_TOPIC: "false"
+  LTD_EVENTS_KAFKA_TOPIC: "ltd.events"
+  OOK_GROUP_ID: "ook-queue"
+---
+# Configuration for the ook-queue deployment
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ook-ingest
+data:
+  SAFIR_NAME: "ook"
+  SAFIR_PROFILE: "production"
+  SAFIR_LOGGER: "ook"
+  SAFIR_LOG_LEVEL: "INFO"
+  SAFIR_KAFKA_PROTOCOL: "SSL"
+  SAFIR_KAFKA_BROKER_URL: "events-kafka-bootstrap:9093"
+  SAFIR_KAFKA_CLUSTER_CA: "/var/strimzi-broker/ca.crt"
+  SAFIR_KAFKA_CLIENT_CA: "/var/strimzi-client/ca.crt"
+  SAFIR_KAFKA_CLIENT_CERT: "/var/strimzi-client/user.crt"
+  SAFIR_KAFKA_CLIENT_KEY: "/var/strimzi-client/user.key"
+  SAFIR_SCHEMA_REGISTRY_URL: "http://schemaregistry:8081"
+  SAFIR_SCHEMA_SUFFIX: ""
+  SAFIR_SCHEMA_COMPATIBILITY: "FORWARD_TRANSITIVE"
+  ENABLE_LTD_EVENTS_KAFKA_TOPIC: "false"
+  ENABLE_OOK_INGEST_KAFKA_TOPIC: "true"
+  OOK_INGEST_KAFKA_TOPIC: "ook.ingest"
+  OOK_GROUP_ID: "ook-ingest"
+  ALGOLIA_APP_ID: "0OJETYIVL5"
+  ALGOLIA_DOCUMENT_INDEX: "document_dev"

--- a/deployments/ook/patches/deployment.yaml
+++ b/deployments/ook/patches/deployment.yaml
@@ -1,0 +1,56 @@
+---
+# ook-queue deployment
+# ook-queue exposes an HTTP API
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ook-queue
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: app
+          volumeMounts:
+            - name: "client-tls"
+              mountPath: "/var/strimzi-client"
+              readOnly: True
+            - name: "broker-tls"
+              mountPath: "/var/strimzi-broker"
+              readOnly: True
+      volumes:
+        # Mount the TLS secret created by KafkaUser
+        - name: "client-tls"
+          secret:
+            secretName: kafkauser-ook-queue  # matches name of KafkaUser
+        - name: "broker-tls"
+          secret:
+            secretName: "events-cluster-ca-cert" # matches name of Strimzi cluster cluster CA cert secret
+---
+# ook-ingest deployment
+# ook-ingest is the backend that consumes the ook.ingest Kafka topic
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ook-ingest
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: app
+          volumeMounts:
+            - name: "client-tls"
+              mountPath: "/var/strimzi-client"
+              readOnly: True
+            - name: "broker-tls"
+              mountPath: "/var/strimzi-broker"
+              readOnly: True
+      volumes:
+        # Mount the TLS secret created by KafkaUser
+        - name: "client-tls"
+          secret:
+            secretName: kafkauser-ook-ingest  # matches name of KafkaUser
+        - name: "broker-tls"
+          secret:
+            secretName: "events-cluster-ca-cert" # matches name of Strimzi cluster cluster CA cert secret

--- a/deployments/ook/resources/vaultsecret.yaml
+++ b/deployments/ook/resources/vaultsecret.yaml
@@ -1,0 +1,9 @@
+---
+# Vault secret reference for the ook deployments
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: ook
+spec:
+  path: secret/k8s_operator/roundtable/ook
+  type: Opaque


### PR DESCRIPTION
This adds Ook (https://github.com/lsst-sqre/ook) to Roundtable:

- Adds the ook Argo CD Application to app-land
- Adds the deployment, which consists of two Deployments:
   1. ook-queue (the front-end pods)
   2. ook-ingest (the back-end pods)
- Adds the ook.ingest Kafka topic
- Adds the ook-ingest and ook-queue KafkaUsers.