### PR TITLE
Ignore differences in cert-manager webhooks

### DIFF
--- a/deployments/security/resources/cert-manager.yaml
+++ b/deployments/security/resources/cert-manager.yaml
@@ -22,3 +22,8 @@ spec:
   syncPolicy:
     automated:
       prune: true
+  ignoreDifferences:
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+      jsonPointers:
+        - "/webhooks/0/clientConfig/caBundle"


### PR DESCRIPTION
The MutatingWebhookConfiguration resources for cert-manager add a
caBundle attribute dynamically.  Tell Argo CD to ignore that for
calculating differences.