### PR TITLE
[DM-25624] Upgrade Vault to 1.4.1

### DIFF
--- a/deployments/vault/values.yaml
+++ b/deployments/vault/values.yaml
@@ -7,7 +7,7 @@ vault:
 
   server:
     image:
-      tag: "1.3.2"
+      tag: "1.4.1"
 
     ingress:
       enabled: true


### PR DESCRIPTION
Upgrade Vault to the latest release.  I reviewed the upgrading
guides at:

https://www.vaultproject.io/docs/upgrading/upgrade-to-1.4.0

and for the other version increases, and none of them seem relevant
to this deployment.