### PR TITLE
[DM-25624] Pin the fluentd-elasticsearch version

### DIFF
--- a/deployments/logging/requirements.yaml
+++ b/deployments/logging/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: opendistro-es
-  version: "1.4.0"
+  version: 1.4.0
   repository: https://lsst-sqre.github.io/charts/
 - name: fluentd-elasticsearch
-  version: ">=3.0.0"
+  version: 9.3.2
   repository: https://kiwigrid.github.io

--- a/deployments/roundtable/resources/logging.yaml
+++ b/deployments/roundtable/resources/logging.yaml
@@ -14,3 +14,6 @@ spec:
     path: deployments/logging
     repoURL: https://github.com/lsst-sqre/roundtable.git
     targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true


### PR DESCRIPTION
Pin to the latest version so that we won't attempt to automatically
pick up newer versions and show as out-of-date on Argo CD and enable
automatic synchronization to match the other Roundtable
configurations.