### PR TITLE
[DM-25624] Force the external IP for nginx-ingress

### DIFF
--- a/deployments/nginx-ingress/values.yaml
+++ b/deployments/nginx-ingress/values.yaml
@@ -9,3 +9,4 @@ nginx-ingress:
       enabled: true
     service:
       externalTrafficPolicy: Local
+      loadBalancerIP: "35.238.16.244"


### PR DESCRIPTION
Per the documentation, GKE should support this feature.