### PR TITLE
[DM-25624] Upgrade Argo CD to 1.6.1

### DIFF
--- a/deployments/argo-cd/kustomization.yaml
+++ b/deployments/argo-cd/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/argoproj/argo-cd//manifests/cluster-install?ref=v1.2.0
+- github.com/argoproj/argo-cd//manifests/cluster-install?ref=v1.6.1
 - resources/argocd-ui-ingress.yaml
 - resources/argocd-grpc-ingress.yaml
 - resources/argocd-metrics.yaml


### PR DESCRIPTION
Upgrade Argo CD to the latest version.  This will require a newer
Argo CD client, but otherwise none of the upgrade notes indicate
problems for Roundtable that I can see.