### PR TITLE
DM-25659: Release templatebot 0.1.2, -aide 0.3.3

### DIFF
--- a/deployments/templatebot/kustomization.yaml
+++ b/deployments/templatebot/kustomization.yaml
@@ -6,8 +6,8 @@ namespace: events
 resources:
   - resources/templatebot-sealedsecret.yaml
   - resources/templatebot-aide-sealedsecret.yaml
-  - github.com/lsst-sqre/templatebot.git//manifests/base?ref=tickets/DM-25659
-  - github.com/lsst-sqre/lsst-templatebot-aide.git//manifests/base?ref=tickets/DM-25659
+  - github.com/lsst-sqre/templatebot.git//manifests/base?ref=0.1.2
+  - github.com/lsst-sqre/lsst-templatebot-aide.git//manifests/base?ref=0.3.3
 
 patches:
   - patches/templatebot-configmap.yaml


### PR DESCRIPTION
This releases templatebot 0.1.2 (https://github.com/lsst-sqre/templatebot/pull/11) and lsst-templatebot-aide 0.3.3 (https://github.com/lsst-sqre/lsst-templatebot-aide/pull/11)