### PR TITLE
DM-25740: Switch to DM-25740 branch of ltd-keeper

### DIFF
--- a/deployments/lsst-the-docs/kustomization.yaml
+++ b/deployments/lsst-the-docs/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 resources:
 - resources/keeper-sealedsecret.yaml
 - resources/cloudsql-sealedsecret.yaml
-- github.com/lsst-sqre/ltd-keeper.git//manifests?ref=master
+- github.com/lsst-sqre/ltd-keeper.git//manifests?ref=tickets/DM-25740
 - resources/keeper-ingress.yaml
 - github.com/lsst-sqre/ltd-dasher.git//manifests?ref=0.1.6
 
@@ -12,7 +12,3 @@ patches:
   - patches/keeper-deployment.yaml
 
 namespace: lsst-the-docs
-
-images:
-  - name: lsstsqre/ltd-keeper
-    newTag: 1.18.0


### PR DESCRIPTION
This enables testing of the new version under the realistic nginx-ingress conditions.