### PR TITLE
DM-25740: Configure LTD to use ProxyFix

### DIFF
--- a/deployments/lsst-the-docs/kustomization.yaml
+++ b/deployments/lsst-the-docs/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - github.com/lsst-sqre/ltd-dasher.git//manifests?ref=0.1.6
 
 patches:
+  - patches/keeper-cm.yaml
   - patches/keeper-deployment.yaml
 
 namespace: lsst-the-docs

--- a/deployments/lsst-the-docs/patches/keeper-deployment.yaml
+++ b/deployments/lsst-the-docs/patches/keeper-deployment.yaml
@@ -11,6 +11,30 @@ spec:
           env:
             - name: LTD_EVENTS_URL
               value: "http://ltdevents.events:8080/webhook"
+        - name: app
+          env:
+            - name: LTD_EVENTS_URL
+              value: "http://ltdevents.events:8080/webhook"
+            - name: LTD_KEEPER_PROXY_FIX
+              valueFrom:
+                configMapKeyRef:
+                  name: keeper
+                  key: LTD_KEEPER_PROXY_FIX
+            - name: LTD_KEEPER_TRUST_X_FOR
+              valueFrom:
+                configMapKeyRef:
+                  name: keeper
+                  key: LTD_KEEPER_TRUST_X_FOR
+            - name: LTD_KEEPER_TRUST_X_PROTO
+              valueFrom:
+                configMapKeyRef:
+                  name: keeper
+                  key: LTD_KEEPER_TRUST_X_PROTO
+            - name: LTD_KEEPER_TRUST_X_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: keeper
+                  key: LTD_KEEPER_TRUST_X_HOST
 
 ---
 # Deployment of celery workers for keeper
@@ -26,3 +50,23 @@ spec:
           env:
             - name: LTD_EVENTS_URL
               value: "http://ltdevents.events:8080/webhook"
+            - name: LTD_KEEPER_PROXY_FIX
+              valueFrom:
+                configMapKeyRef:
+                  name: keeper
+                  key: LTD_KEEPER_PROXY_FIX
+            - name: LTD_KEEPER_TRUST_X_FOR
+              valueFrom:
+                configMapKeyRef:
+                  name: keeper
+                  key: LTD_KEEPER_TRUST_X_FOR
+            - name: LTD_KEEPER_TRUST_X_PROTO
+              valueFrom:
+                configMapKeyRef:
+                  name: keeper
+                  key: LTD_KEEPER_TRUST_X_PROTO
+            - name: LTD_KEEPER_TRUST_X_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: keeper
+                  key: LTD_KEEPER_TRUST_X_HOST


### PR DESCRIPTION
This enables the new proxy header trust settings available in LTD Keeper version 1.19.0.