### PR TITLE
Use full URL for Argo CD manifest

### DIFF
--- a/deployments/argo-cd/kustomization.yaml
+++ b/deployments/argo-cd/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/argoproj/argo-cd//manifests/cluster-install?ref=v1.6.1
+- https://github.com/argoproj/argo-cd/manifests/cluster-install?ref=v1.6.1
 - resources/argocd-ui-ingress.yaml
 - resources/argocd-grpc-ingress.yaml
 - resources/argocd-metrics.yaml


### PR DESCRIPTION
This works around the issue discussed in https://github.com/argoproj/argo-cd/issues/3814 due to changes in kustomize and go-getter. Essentially, with the `//` technique of downloading a single directory, other directories outside that tree
couldn't be resolved.