### PR TITLE
[DM-25844] Add missing configuration for neophile

### DIFF
--- a/deployments/app-land/kustomization.yaml
+++ b/deployments/app-land/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - resources/checkerboard.yaml
   - resources/lsst-the-docs.yaml
   - resources/ltdevents.yaml
+  - resources/neophile.yaml
   - resources/safirdemo.yaml
   - resources/sqrbot-jr.yaml
   - resources/sqrbot-jsick.yaml

--- a/deployments/neophile/values.yaml
+++ b/deployments/neophile/values.yaml
@@ -8,6 +8,7 @@ neophile:
       repo: "checkerboard"
     - owner: "lsst-sqre"
       repo: "gafaelfawr"
+  vault_secrets_path: "secret/k8s_operator/roundtable/neophile"
 
   # For testing, run daily at 4am.
   schedule: "0 4 * * *"


### PR DESCRIPTION
Add the Vault path to the secret and include the application in the
app-land configuration.