### PR TITLE
[DM-25844] Use defaults for neophile

### DIFF
--- a/deployments/neophile/requirements.yaml
+++ b/deployments/neophile/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: neophile
-    version: 0.1.0
+    version: 0.1.1
     repository: https://lsst-sqre.github.io/charts/

--- a/deployments/neophile/values.yaml
+++ b/deployments/neophile/values.yaml
@@ -1,9 +1,6 @@
 neophile:
   github_email: "24442459+sqrbot@users.noreply.github.com"
   github_user: "sqrbot"
-  image:
-    tag: "tickets-DM-25844"
-    pullPolicy: "Always"
   repositories:
     - owner: "lsst-sqre"
       repo: "checkerboard"
@@ -12,6 +9,3 @@ neophile:
     - owner: "lsst-sqre"
       repo: "neophile"
   vault_secrets_path: "secret/k8s_operator/roundtable/neophile"
-
-  # For testing, run daily at 4am.
-  schedule: "0 4 * * *"


### PR DESCRIPTION
Use the default schedule and the default image, now that 0.1.0 has
been formally released and everything seems to be working.