### PR TITLE
Convert Vault wrapper chart to apiVersion: v2

### DIFF
--- a/deployments/vault/Chart.yaml
+++ b/deployments/vault/Chart.yaml
@@ -1,3 +1,7 @@
-apiVersion: v1
+apiVersion: v2
 name: vault
 version: 1.0.0
+dependencies:
+  - name: vault
+    version: 0.6.0
+    repository: https://helm.releases.hashicorp.com

--- a/deployments/vault/requirements.yaml
+++ b/deployments/vault/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-  - name: vault
-    version: 0.6.0
-    repository: https://helm.releases.hashicorp.com


### PR DESCRIPTION
Roundtable is unable to sync because the upstream Helm chart is now
apiVersion: v2.  See if the problem is that the wrapper chart is not
apiVersion: v2, so Argo CD is explicitly invoking helm2 on it.