### PR TITLE
DM-26354: Add ltd-keeper to neophile

### DIFF
--- a/deployments/neophile/values.yaml
+++ b/deployments/neophile/values.yaml
@@ -9,6 +9,8 @@ neophile:
     - owner: "lsst-sqre"
       repo: "kafka-aggregator"
     - owner: "lsst-sqre"
+      repo: "ltd-keeper"
+    - owner: "lsst-sqre"
       repo: "neophile"
     - owner: "lsst-sqre"
       repo: "ook"


### PR DESCRIPTION
In https://github.com/lsst-sqre/ltd-keeper/pull/53 we upgraded LTD Keeper to use resolved/pinned dependencies, so we can now use neophile to keep those dependencies up to date.