### PR TITLE
[DM-26508] Bump memory allocation for Kibana pods

### DIFF
--- a/deployments/logging/values.yaml
+++ b/deployments/logging/values.yaml
@@ -5,9 +5,21 @@ opendistro-es:
       storageClassName: standard
     data:
       replicas: 3
+      javaOpts: "-Xms1g -Xmx1g"
+      resources:
+        limits:
+          memory: 1G
+        requests:
+          memory: 1G
       storageClassName: standard
     client:
       replicas: 2
+      javaOpts: "-Xms1g -Xmx1g"
+      resources:
+        limits:
+          memory: 1G
+        requests:
+          memory: 1G
       ingress:
         enabled: false
 


### PR DESCRIPTION
Copy the settings from the lsp-deploy configuration but lower the
limits.  See if this addresses the issues with searching.