### PR TITLE
[DM-26508] Further increase Kubernetes memory requests

### DIFF
--- a/deployments/logging/values.yaml
+++ b/deployments/logging/values.yaml
@@ -8,18 +8,18 @@ opendistro-es:
       javaOpts: "-Xms1g -Xmx1g"
       resources:
         limits:
-          memory: 1G
+          memory: 2G
         requests:
-          memory: 1G
+          memory: 2G
       storageClassName: standard
     client:
       replicas: 2
       javaOpts: "-Xms1g -Xmx1g"
       resources:
         limits:
-          memory: 1G
+          memory: 2G
         requests:
-          memory: 1G
+          memory: 2G
       ingress:
         enabled: false
 


### PR DESCRIPTION
Telling Java to use 1GB but only requesting 1GB and limiting to 1GB
doesn't work for obvious reasons.  Request 2GB of memory and let
Java use 1GB of it.