### PR TITLE
[DM-26508] Fix elasticsearch host in fluentd configuration

### DIFF
--- a/deployments/logging/values.yaml
+++ b/deployments/logging/values.yaml
@@ -29,7 +29,7 @@ opendistro-es:
 
 fluentd-elasticsearch:
   elasticsearch:
-    host: logging-opendistro-es-client-service
+    hosts: ["logging-opendistro-es-client-service:9200"]
     scheme: https
     sslVerify: false
     auth:


### PR DESCRIPTION
The configuration syntax apparently changed with the new version
to require a list of hosts including the port number.