### PR TITLE
DM-26527: Add ltd-conveyor to neophile config

### DIFF
--- a/deployments/neophile/values.yaml
+++ b/deployments/neophile/values.yaml
@@ -9,6 +9,8 @@ neophile:
     - owner: "lsst-sqre"
       repo: "kafka-aggregator"
     - owner: "lsst-sqre"
+      repo: "ltd-conveyor"
+    - owner: "lsst-sqre"
       repo: "ltd-keeper"
     - owner: "lsst-sqre"
       repo: "neophile"


### PR DESCRIPTION
sqrbot also has write permissions on the lsst-sqre/ltd-conveyor repo.