### PR TITLE
[DM-26507] Document Argo CD upgrade, bump version

### DIFF
--- a/deployments/argo-cd/kustomization.yaml
+++ b/deployments/argo-cd/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://github.com/argoproj/argo-cd/manifests/cluster-install?ref=v1.6.1
+- https://github.com/argoproj/argo-cd/manifests/cluster-install?ref=v1.7.3
 - resources/argocd-ui-ingress.yaml
 - resources/argocd-grpc-ingress.yaml
 - resources/argocd-metrics.yaml

--- a/docs/ops/argo-cd/index.rst
+++ b/docs/ops/argo-cd/index.rst
@@ -32,3 +32,4 @@ The web dashboard for Roundtable's Argo CD is https://cd.roundtable.lsst.codes.
    github-webhook
    port-forward
    grafana-dashboard
+   upgrading

--- a/docs/ops/argo-cd/upgrading.rst
+++ b/docs/ops/argo-cd/upgrading.rst
@@ -1,0 +1,17 @@
+#################
+Upgrading Argo CD
+#################
+
+Argo CD cannot upgrade itself, so upgrades must be done manually.
+In Roundtable, Argo CD is configured to be aware of itself via the ``argo-cd`` app, but this is only for the UI display.
+Do not try to sync the ``argo-cd`` app to perform an upgrade; it will fail and probably bring down the UI.
+(It's fine to sync the ``argo-cd`` app to update resources that are added by the Roundtable configuration.)
+
+To upgrade Argo CD:
+
+#. Go to the `Argo CD GitHub page <https://github.com/argoproj/argo-cd>`__ and determine the latest release.
+   You can also check the Roundtable repository with ``neophile analyze`` (see the `neophile documentation <https://neophile.lsst.io/>`__ for more information).
+#. Update the `Argo CD configuration <https://github.com/lsst-sqre/roundtable/blob/master/deployments/argo-cd/kustomization.yaml>`__ to point to the latest version.
+   This will not upgrade Argo CD, but it will allow you to see what will change via the UI.
+#. Read the upgrade notes and then upgrade Argo CD following the `upstream instructions <https://argoproj.github.io/argo-cd/operator-manual/upgrading/overview/>`__.
+   Roundtable uses the non-HA configuration.

--- a/docs/ops/argo-cd/upgrading.rst
+++ b/docs/ops/argo-cd/upgrading.rst
@@ -2,16 +2,11 @@
 Upgrading Argo CD
 #################
 
-Argo CD cannot upgrade itself, so upgrades must be done manually.
-In Roundtable, Argo CD is configured to be aware of itself via the ``argo-cd`` app, but this is only for the UI display.
-Do not try to sync the ``argo-cd`` app to perform an upgrade; it will fail and probably bring down the UI.
-(It's fine to sync the ``argo-cd`` app to update resources that are added by the Roundtable configuration.)
-
 To upgrade Argo CD:
 
 #. Go to the `Argo CD GitHub page <https://github.com/argoproj/argo-cd>`__ and determine the latest release.
    You can also check the Roundtable repository with ``neophile analyze`` (see the `neophile documentation <https://neophile.lsst.io/>`__ for more information).
 #. Update the `Argo CD configuration <https://github.com/lsst-sqre/roundtable/blob/master/deployments/argo-cd/kustomization.yaml>`__ to point to the latest version.
    This will not upgrade Argo CD, but it will allow you to see what will change via the UI.
-#. Read the upgrade notes and then upgrade Argo CD following the `upstream instructions <https://argoproj.github.io/argo-cd/operator-manual/upgrading/overview/>`__.
-   Roundtable uses the non-HA configuration.
+#. Read the `upgrade notes <https://argoproj.github.io/argo-cd/operator-manual/upgrading/overview/>`__ to see if there are any changes to adjust for.
+#. Tell Argo CD to sync the update.


### PR DESCRIPTION
Document how to upgrade Argo CD on Roundtable and bump the version
in the Kustomize external resource in preparation for that upgrade.