### PR TITLE
Update cert-manager ClusterIssuer to stable API

### DIFF
--- a/deployments/cert-manager/templates/cluster-issuer.yaml
+++ b/deployments/cert-manager/templates/cluster-issuer.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-issuer


### PR DESCRIPTION
We've upgraded Roundtable to cert-manager v1, so update the
apiVersion of the ClusterIssuer resource to use the stable API.