### PR TITLE
[DM-25727] Deploy Gafaelfawr on Roundtable

### DIFF
--- a/deployments/app-land/kustomization.yaml
+++ b/deployments/app-land/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - resources/lsst-the-docs-ns.yaml
   # Applications
   - resources/checkerboard.yaml
+  - resources/gafaelfawr.yaml
   - resources/lsst-the-docs.yaml
   - resources/ltdevents.yaml
   - resources/neophile.yaml

--- a/deployments/app-land/kustomization.yaml
+++ b/deployments/app-land/kustomization.yaml
@@ -8,7 +8,6 @@ resources:
   - resources/lsst-the-docs-ns.yaml
   # Applications
   - resources/checkerboard.yaml
-  - resources/gafaelfawr.yaml
   - resources/lsst-the-docs.yaml
   - resources/ltdevents.yaml
   - resources/neophile.yaml

--- a/deployments/app-land/resources/gafaelfawr.yaml
+++ b/deployments/app-land/resources/gafaelfawr.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gafaelfawr
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gafaelfawr
+spec:
+  destination:
+    namespace: gafaelfawr
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: deployments/gafaelfawr
+    repoURL: https://github.com/lsst-sqre/roundtable
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true

--- a/deployments/gafaelfawr/Chart.yaml
+++ b/deployments/gafaelfawr/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: gafaelfawr
+version: 1.0.0

--- a/deployments/gafaelfawr/requirements.yaml
+++ b/deployments/gafaelfawr/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - name: gafaelfawr
+    version: 1.4.6
+    repository: https://lsst-sqre.github.io/charts/

--- a/deployments/gafaelfawr/values.yaml
+++ b/deployments/gafaelfawr/values.yaml
@@ -13,3 +13,7 @@ gafaelfawr:
 
   oidc_server:
     enabled: true
+
+  group_mapping:
+    "exec:admin":
+      - "lsst-sqre-square"

--- a/deployments/gafaelfawr/values.yaml
+++ b/deployments/gafaelfawr/values.yaml
@@ -1,0 +1,15 @@
+gafaelfawr:
+  host: roundtable.lsst.codes
+  ingress:
+    host: roundtable.lsst.codes
+  vault_secrets_path: "secret/k8s_operator/roundtable/gafaelfawr"
+
+  image:
+    tag: "tickets-DM-26602"
+    pullPolicy: "Always"
+
+  github:
+    client_id: 4e2ca7a338b0435060ad
+
+  oidc_server:
+    enabled: true

--- a/deployments/roundtable/kustomization.yaml
+++ b/deployments/roundtable/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - resources/logging-ns.yaml
   # Applications
   - resources/argo-cd.yaml
+  - resources/gafaelfawr.yaml
   - resources/prometheus.yaml
   - resources/strimzi.yaml
   - resources/events-dev.yaml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -136,6 +136,10 @@ rst_epilog = """
    :target: https://cd.roundtable.lsst.codes/applications/logging
    :alt: Logging app status
 
+.. |gafaelfawr-status| image:: https://cd.roundtable.lsst.codes/api/badge?name=gafaelfawr
+   :target: https://cd.roundtable.lsst.codes/applications/gafaelfawr
+   :alt: Gafaelfawr app status
+
 .. _Elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
 .. _Kibana: https://www.elastic.co/guide/en/kibana/current/index.html
 .. _Helm: https://helm.sh

--- a/docs/ops/argo-cd/upgrading.rst
+++ b/docs/ops/argo-cd/upgrading.rst
@@ -34,7 +34,7 @@ This is taken from the `Argo CD disaster recovery documentation <https://argopro
 
 If anything goes horribly wrong, you can then restore the configuration with:
 
-.. code-block::
+.. code-block:: console
 
    $ chmod 644 ~/.kube/config
    $ docker run -i -v ~/.kube:/home/argocd/.kube --rm \

--- a/docs/ops/gafaelfawr/index.rst
+++ b/docs/ops/gafaelfawr/index.rst
@@ -1,0 +1,23 @@
+###############################
+gafaelfawr app deployment guide
+###############################
+
+.. list-table::
+   :widths: 10,40
+
+   * - Deployment
+     - |gafaelfawr-status|
+   * - Edit on GitHub
+     - `/deployments/gafaelfawr <https://github.com/lsst-sqre/roundtable/tree/master/deployments/gafaelfawr>`__
+   * - Type
+     - Helm_
+   * - Parent app
+     - :doc:`roundtable <../roundtable/index>`
+
+.. rubric:: Overview
+
+This Argo CD Application deploys and configures `Gafaelfawr <https://gafaelfawr.lsst.io/>`__, an authentication proxy and token management system.
+Gafaelfawr is used to authenticate access to :doc:`Kibana <../logging/index>`.
+
+It is configured to use GitHub for authentication.
+Only members of the ``square`` team in the ``lsst-sqre`` organization currently have access to protected resources.

--- a/docs/ops/index.rst
+++ b/docs/ops/index.rst
@@ -13,12 +13,13 @@ Although this documentation is openly available, application developers shouldn'
    roundtable/index
    app-land/index
    argo-cd/index
-   nginx-ingress/index
    cert-manager/index
-   prometheus/index
-   strimzi/index
    events/index
+   gafaelfawr/index
+   logging/index
+   nginx-ingress/index
+   prometheus/index
    sealed-secrets/index
+   strimzi/index
    vault/index
    vault-secrets-operator/index
-   logging/index

--- a/docs/ops/roundtable/index.rst
+++ b/docs/ops/roundtable/index.rst
@@ -25,6 +25,7 @@ It deploys:
 - The core infrastructure apps:
 
   - :doc:`argo-cd <../argo-cd/index>` for continuous delivery of Roundtable apps with Argo CD.
+  - :doc:`gafaelfawr <../gafaelfawr/index` for OpenID Connect web authentication.
   - :doc:`prometheus <../prometheus/index>` for the Kubernetes-native monitoring stack (Prometheus Operator, Prometheus, and Grafana).
   - :doc:`vault-secrets-operator <../vault-secrets-operator/index>` to retrieve secrets from Vault and store them as Kubernetes secrets.
 


### PR DESCRIPTION
This will take over the /login, /logout, and /auth routes, which
should be merged with the routes declared by the Roundtable ingress
and inherit the TLS settings from them.

Point at the current development branch since this will be tested as
an OpenID Connect provider for Open Distro for Elasticsearch.