### PR TITLE
[DM-26602] Add security configuration and ingress for Kibana

### DIFF
--- a/deployments/logging/templates/logging-accounts.yaml
+++ b/deployments/logging/templates/logging-accounts.yaml
@@ -1,0 +1,7 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: logging-accounts
+spec:
+  path: "secret/k8s_operator/roundtable/logging"
+  type: Opaque

--- a/deployments/logging/templates/logging-security-config.yaml
+++ b/deployments/logging/templates/logging-security-config.yaml
@@ -1,0 +1,29 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: Secret
+metadata:
+  name: logging-security-config
+type: Opaque
+stringData:
+  config.yml: |-
+    _meta:
+      type: "config"
+      config_version: 2
+
+    config:
+      dynamic:
+        http:
+          xff:
+            enabled: true
+            internalProxies: "10\..*"
+        authc:
+          proxy_auth_domain:
+            http_enabled: true
+            transport_enabled: true
+            order: 0
+            http_authenticator:
+              type: proxy
+              challenge: false
+              config:
+                user_header: "X-Auth-Request-User"
+            authentication_backend:
+              type: noop

--- a/deployments/logging/templates/networkpolicy.yaml
+++ b/deployments/logging/templates/networkpolicy.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: logging-networkpolicy
+spec:
+  podSelector:
+    matchLabels:
+      app: logging-opendistro-es
+      role: kibana
+    policyTypes:
+      - Ingress
+    ingress:
+      - from:
+          - podSelector:
+              matchLabels:
+                app: nginx-ingress
+                component: controller
+        ports:
+          - protocol: TCP
+            port: 5601

--- a/deployments/logging/values.yaml
+++ b/deployments/logging/values.yaml
@@ -3,6 +3,7 @@ opendistro-es:
     master:
       replicas: 3
       storageClassName: standard
+
     data:
       replicas: 3
       javaOpts: "-Xms1g -Xmx1g"
@@ -12,6 +13,7 @@ opendistro-es:
         requests:
           memory: 2G
       storageClassName: standard
+
     client:
       replicas: 2
       javaOpts: "-Xms1g -Xmx1g"
@@ -23,9 +25,38 @@ opendistro-es:
       ingress:
         enabled: false
 
+    securityConfig:
+      enabled: true
+      configSecret: "logging-security-config"
+      internalUsersSecret: "logging-accounts"
+
   kibana:
+    config:
+      elasticsearch.username: "${ELASTICSEARCH_USERNAME}"
+      elasticsearch.password: "${ELASTICSEARCH_PASSWORD}"
+      elasticsearch.requestHeadersWhitelist:
+        - "Authorization"
+        - "X-Forwarded-For"
+        - "X-Auth-Request-User"
+        - "X-Proxy-Roles"
+      opendistro_security.auth.type: "proxy"
+      opendistro_security.cookie.secure: true
+      opendistro_security.cookie.password: "${COOKIE_PASS}"
+
+    elasticsearchAccount:
+      secret: "logging-accounts"
+
     ingress:
-      enabled: false
+      enabled: true
+      annotations:
+        nginx.ingress.kubernetes.io/auth-method: "GET"
+        nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
+        nginx.ingress.kubernetes.io/auth-signin: "https://roundtable.lsst.codes/login"
+        nginx.ingress.kubernetes.io/auth-url: "https://roundtable.lsst.codes/auth?scope=exec:admin"
+        nginx.ingress.kubernetes.io/configuration-snippet: |
+          proxy_set_header X-Proxy-Roles "all_access"
+      hosts:
+        - "roundtable.lsst.codes/logs"
 
 fluentd-elasticsearch:
   elasticsearch:
@@ -34,8 +65,13 @@ fluentd-elasticsearch:
     sslVerify: false
     auth:
       enabled: true
-      user: admin
-      password: admin
+      user: "logstash"
+      # Get password from the logging-accounts secret.
+      password: ""
+    secret:
+      - name: OUTPUT_PASSWORD
+        secret_name: "logging-accounts"
+        secret_key: "logstash-password"
     configMaps:
       useDefaults:
         containersInputConf: false


### PR DESCRIPTION
Use Gafaelfawr to authenticate Kibana from Open Distro for
Elasticsearch via proxy authentication.  This looks simpler than
using OpenID Connect on the Kubernetes configuration side.

Enable the ingress but limit access to nginx-ingress via a
network policy.

Explicitly configure the users and passwords for Kibana and
logstash using a secret rather than using the default values.