### PR TITLE
[DM-26602] Fix apiVersion for logging secret

### DIFF
--- a/deployments/logging/templates/logging-security-config.yaml
+++ b/deployments/logging/templates/logging-security-config.yaml
@@ -1,4 +1,4 @@
-apiVersion: ricoberger.de/v1alpha1
+apiVersion: v1
 kind: Secret
 metadata:
   name: logging-security-config


### PR DESCRIPTION
The regular Secret should be v1, not the apiVersion for a
VaultSecret.