### PR TITLE
[DM-26602] Relax elasticsearch-master liveness probe

### DIFF
--- a/deployments/logging/values.yaml
+++ b/deployments/logging/values.yaml
@@ -3,6 +3,11 @@ opendistro-es:
     master:
       replicas: 3
       storageClassName: standard
+      livenessProbe:
+        tcpSocket:
+          port: transport
+        initialDelaySeconds: 180
+        periodSeconds: 10
 
     data:
       replicas: 3


### PR DESCRIPTION
It's way too aggressive at one minute.  The software was still
starting when it was killed.  Increase to two minutes.