### PR TITLE
[DM-26602] Fix escaping of proxy logging config

### DIFF
--- a/deployments/logging/templates/logging-security-config.yaml
+++ b/deployments/logging/templates/logging-security-config.yaml
@@ -14,7 +14,7 @@ stringData:
         http:
           xff:
             enabled: true
-            internalProxies: "10\..*"
+            internalProxies: "10\\..*"
         authc:
           proxy_auth_domain:
             http_enabled: true


### PR DESCRIPTION
Backslashes in quoted strings need to be doubled.