### PR TITLE
[DM-26602] Allow other logging pods to connect to Kibana

### DIFF
--- a/deployments/logging/templates/networkpolicy.yaml
+++ b/deployments/logging/templates/networkpolicy.yaml
@@ -15,6 +15,9 @@ spec:
             matchLabels:
               app: nginx-ingress
               component: controller
+          podSelector:
+            matchLabels:
+              app: logging-opendistro-es
       ports:
         - protocol: TCP
           port: 5601


### PR DESCRIPTION
See if this is the problem with Kibana being unable to talk to the
rest of the cluster.