### PR TITLE
[DM-26602] Fix indentation for fluentd-elasticsearch config

### DIFF
--- a/deployments/logging/templates/networkpolicy.yaml
+++ b/deployments/logging/templates/networkpolicy.yaml
@@ -15,7 +15,7 @@ spec:
             matchLabels:
               app: nginx-ingress
               component: controller
-          podSelector:
+        - podSelector:
             matchLabels:
               app: logging-opendistro-es
       ports:

--- a/deployments/logging/values.yaml
+++ b/deployments/logging/values.yaml
@@ -73,74 +73,74 @@ fluentd-elasticsearch:
       user: "logstash"
       # Get password from the logging-accounts secret.
       password: ""
-    secret:
-      - name: OUTPUT_PASSWORD
-        secret_name: "logging-accounts"
-        secret_key: "logstash-password"
-    configMaps:
-      useDefaults:
-        containersInputConf: false
-    extraConfigMaps:
-      kubernetes.input.conf: |-
-        <source>
-          @id fluentd-containers.log
-          @type tail
-          path /var/log/containers/*.log
-          pos_file /var/log/containers.log.pos
-          tag raw.kubernetes.*
-          read_from_head true
-          <parse>
-            @type multi_format
-            <pattern>
-              format json
-              time_key time
-              time_format %Y-%m-%dT%H:%M:%S.%NZ
-            </pattern>
-            <pattern>
-              format /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
-              time_format %Y-%m-%dT%H:%M:%S.%N%:z
-            </pattern>
-          </parse>
-        </source>
-        # Detect exceptions in the log output and forward them as one log entry.
-        <match raw.kubernetes.**>
-          @id raw.kubernetes
-          @type detect_exceptions
-          remove_tag_prefix raw
-          message log
-          stream stream
-          multiline_flush_interval 5
-          max_bytes 500000
-          max_lines 1000
-        </match>
-        # Concatenate multi-line logs
-        #<filter **>
-        <filter kubernetes.**>
-          @id filter_concat
-          @type concat
-          key message
-          multiline_end_regexp /\n$/
-          separator ""
-        </filter>
-        # Enriches records with Kubernetes metadata
-        <filter kubernetes.**>
-          @id filter_kubernetes_metadata
-          @type kubernetes_metadata
-        </filter>
-        # Fixes json fields in Elasticsearch
-        <filter kubernetes.**>
-          @id filter_parser
-          @type parser
-          key_name log
-          reserve_data true
-          remove_key_name_field true
-          <parse>
-            @type multi_format
-            <pattern>
-              format json
-            </pattern>
-            <pattern>
-              format none
-            </pattern>
-          </parse>
-        </filter>
+  secret:
+    - name: OUTPUT_PASSWORD
+      secret_name: "logging-accounts"
+      secret_key: "logstash-password"
+  configMaps:
+    useDefaults:
+      containersInputConf: false
+  extraConfigMaps:
+    kubernetes.input.conf: |-
+      <source>
+        @id fluentd-containers.log
+        @type tail
+        path /var/log/containers/*.log
+        pos_file /var/log/containers.log.pos
+        tag raw.kubernetes.*
+        read_from_head true
+        <parse>
+          @type multi_format
+          <pattern>
+            format json
+            time_key time
+            time_format %Y-%m-%dT%H:%M:%S.%NZ
+          </pattern>
+          <pattern>
+            format /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
+            time_format %Y-%m-%dT%H:%M:%S.%N%:z
+          </pattern>
+        </parse>
+      </source>
+      # Detect exceptions in the log output and forward them as one log entry.
+      <match raw.kubernetes.**>
+        @id raw.kubernetes
+        @type detect_exceptions
+        remove_tag_prefix raw
+        message log
+        stream stream
+        multiline_flush_interval 5
+        max_bytes 500000
+        max_lines 1000
+      </match>
+      # Concatenate multi-line logs
+      #<filter **>
+      <filter kubernetes.**>
+        @id filter_concat
+        @type concat
+        key message
+        multiline_end_regexp /\n$/
+        separator ""
+      </filter>
+      # Enriches records with Kubernetes metadata
+      <filter kubernetes.**>
+        @id filter_kubernetes_metadata
+        @type kubernetes_metadata
+      </filter>
+      # Fixes json fields in Elasticsearch
+      <filter kubernetes.**>
+        @id filter_parser
+        @type parser
+        key_name log
+        reserve_data true
+        remove_key_name_field true
+        <parse>
+          @type multi_format
+          <pattern>
+            format json
+          </pattern>
+          <pattern>
+            format none
+          </pattern>
+        </parse>
+      </filter>


### PR DESCRIPTION
The secrets and configuration maps were not being properly picked
up because they were indented by one too many levels.