### PR TITLE
[DM-26602] Use nginx ingress for Kibana

### DIFF
--- a/deployments/logging/values.yaml
+++ b/deployments/logging/values.yaml
@@ -57,6 +57,7 @@ opendistro-es:
     ingress:
       enabled: true
       annotations:
+        kubernetes.io/ingress.class: nginx
         nginx.ingress.kubernetes.io/auth-method: "GET"
         nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
         nginx.ingress.kubernetes.io/auth-signin: "https://roundtable.lsst.codes/login"


### PR DESCRIPTION
Otherwise it tries to use the GKE ingress, which (a) we don't want,
and (b) doesn't support ClusterIP.