### PR TITLE
[DM-26602] Pass securitytenant header to Elasticsearch

### DIFF
--- a/deployments/logging/values.yaml
+++ b/deployments/logging/values.yaml
@@ -42,6 +42,7 @@ opendistro-es:
       elasticsearch.password: "${ELASTICSEARCH_PASSWORD}"
       elasticsearch.requestHeadersWhitelist:
         - "Authorization"
+        - "securitytenant"
         - "X-Forwarded-For"
         - "X-Auth-Request-User"
         - "X-Proxy-Roles"


### PR DESCRIPTION
See if this explains why permission is denied for all actions in
Kibana.