### PR TITLE
[DM-26602] Set default Elasticsearch role to admin

### DIFF
--- a/deployments/logging/values.yaml
+++ b/deployments/logging/values.yaml
@@ -67,7 +67,7 @@ opendistro-es:
         nginx.ingress.kubernetes.io/auth-signin: "https://roundtable.lsst.codes/login"
         nginx.ingress.kubernetes.io/auth-url: "https://roundtable.lsst.codes/auth?scope=exec:admin"
         nginx.ingress.kubernetes.io/configuration-snippet: |
-          proxy_set_header X-Proxy-Roles "all_access";
+          proxy_set_header X-Proxy-Roles "admin";
       hosts:
         - "roundtable.lsst.codes/logs"
 


### PR DESCRIPTION
Trying to use anything other than admin seems to be a recipe for
frustration, so just force the role to admin at least for now.