### PR TITLE
[DM-26602] Test Kibana with OpenID Connect

### DIFF
--- a/deployments/gafaelfawr/requirements.yaml
+++ b/deployments/gafaelfawr/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: gafaelfawr
-    version: 1.5.0
+    version: 1.5.1
     repository: https://lsst-sqre.github.io/charts/

--- a/deployments/logging/templates/logging-security-config.yaml
+++ b/deployments/logging/templates/logging-security-config.yaml
@@ -11,10 +11,6 @@ stringData:
 
     config:
       dynamic:
-        http:
-          xff:
-            enabled: true
-            internalProxies: "10\\..*"
         authc:
           basic_internal_auth_domain:
             http_enabled: true
@@ -25,15 +21,17 @@ stringData:
               challenge: false
             authentication_backend:
               type: internal
-          proxy_auth_domain:
+          openid_auth_domain:
             http_enabled: true
             transport_enabled: true
             order: 1
             http_authenticator:
-              type: proxy
+              type: openid
               challenge: false
               config:
-                user_header: "X-Auth-Request-User"
-                roles_header: "X-Proxy-Roles"
+                enable_ssl: true
+                subject_key: sub
+                roles_key: scope
+                openid_connect_url: https://roundtable.lsst.codes/.well-known/openid-configuration
             authentication_backend:
               type: noop

--- a/deployments/logging/values.yaml
+++ b/deployments/logging/values.yaml
@@ -47,10 +47,14 @@ opendistro-es:
         - "x-auth-request-user"
         - "x-proxy-roles"
       elasticsearch.ssl.verificationMode: "none"
-      opendistro_security.auth.type: "proxy"
+      opendistro_security.auth.type: "openid"
       opendistro_security.cookie.secure: true
       opendistro_security.cookie.password: "${COOKIE_PASS}"
       opendistro_security.multitenancy.enabled: false
+      opendistro_security.openid.client_id: "kibana"
+      opendistro_security.openid.client_secret: "${OPENID_SECRET}"
+      opendistro_security.openid.scope: "openid"
+      opendistro_security.openid.logout_url: "https://roundtable.lsst.codes/logout"
       server.basePath: "/logs"
       server.rewriteBasePath: true
       server.host: "0.0.0.0"
@@ -59,16 +63,17 @@ opendistro-es:
     elasticsearchAccount:
       secret: "logging-accounts"
 
+    extraEnvs:
+      - name: OPENID_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: "logging-accounts"
+            key: openid-secret
+
     ingress:
       enabled: true
       annotations:
         kubernetes.io/ingress.class: nginx
-        nginx.ingress.kubernetes.io/auth-method: "GET"
-        nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
-        nginx.ingress.kubernetes.io/auth-signin: "https://roundtable.lsst.codes/login"
-        nginx.ingress.kubernetes.io/auth-url: "https://roundtable.lsst.codes/auth?scope=exec:admin"
-        nginx.ingress.kubernetes.io/configuration-snippet: |
-          proxy_set_header X-Proxy-Roles "admin";
       hosts:
         - "roundtable.lsst.codes/logs"
 


### PR DESCRIPTION
Do an end-to-end test of Kibana with OpenID Connect authentication.
We'll probably still use proxy authentication going forward, but I
want to test whether the OpenID Connect support in Gafaelfawr works
properly.