### PR TITLE
[DM-26602] Fix Kibana OpenID base redirect URL

### DIFF
--- a/deployments/logging/values.yaml
+++ b/deployments/logging/values.yaml
@@ -56,7 +56,7 @@ opendistro-es:
       opendistro_security.openid.scope: "openid"
       opendistro_security.openid.connect_url: "https://roundtable.lsst.codes/.well-known/openid-configuration"
       opendistro_security.openid.logout_url: "https://roundtable.lsst.codes/logout"
-      opendistro_security.openid.base_redirect_url: "https://roundtable.lsst.codes/logs"
+      opendistro_security.openid.base_redirect_url: "https://roundtable.lsst.codes/"
       server.basePath: "/logs"
       server.rewriteBasePath: true
       server.host: "0.0.0.0"


### PR DESCRIPTION
Looks like we're getting an extra /logs parameter.  Try removing it
from the base redirect URL.