### PR TITLE
[DM-26602] Remove roles key from Elasticsearch OpenID config

### DIFF
--- a/deployments/logging/templates/logging-security-config.yaml
+++ b/deployments/logging/templates/logging-security-config.yaml
@@ -31,7 +31,6 @@ stringData:
               config:
                 enable_ssl: true
                 subject_key: sub
-                roles_key: scope
                 openid_connect_url: https://roundtable.lsst.codes/.well-known/openid-configuration
             authentication_backend:
               type: noop


### PR DESCRIPTION
We're not setting scope to a valid format for the Elasticsearch
roles, so try testing without it.