### PR TITLE
[DM-26602] Restore proxy Kibana authentication, document OpenID

### DIFF
--- a/deployments/gafaelfawr/values.yaml
+++ b/deployments/gafaelfawr/values.yaml
@@ -4,10 +4,6 @@ gafaelfawr:
     host: roundtable.lsst.codes
   vault_secrets_path: "secret/k8s_operator/roundtable/gafaelfawr"
 
-  image:
-    tag: "tickets-DM-26602"
-    pullPolicy: "Always"
-
   github:
     client_id: 4e2ca7a338b0435060ad
 

--- a/deployments/logging/templates/logging-security-config.yaml
+++ b/deployments/logging/templates/logging-security-config.yaml
@@ -11,6 +11,10 @@ stringData:
 
     config:
       dynamic:
+        http:
+          xff:
+            enabled: true
+            internalProxies: "10\\..*"
         authc:
           basic_internal_auth_domain:
             http_enabled: true
@@ -21,16 +25,15 @@ stringData:
               challenge: false
             authentication_backend:
               type: internal
-          openid_auth_domain:
+          proxy_auth_domain:
             http_enabled: true
             transport_enabled: true
             order: 1
             http_authenticator:
-              type: openid
+              type: proxy
               challenge: false
               config:
-                enable_ssl: true
-                subject_key: sub
-                openid_connect_url: https://roundtable.lsst.codes/.well-known/openid-configuration
+                user_header: "X-Auth-Request-User"
+                roles_header: "X-Proxy-Roles"
             authentication_backend:
               type: noop

--- a/deployments/logging/values.yaml
+++ b/deployments/logging/values.yaml
@@ -47,16 +47,10 @@ opendistro-es:
         - "x-auth-request-user"
         - "x-proxy-roles"
       elasticsearch.ssl.verificationMode: "none"
-      opendistro_security.auth.type: "openid"
+      opendistro_security.auth.type: "proxy"
       opendistro_security.cookie.secure: true
       opendistro_security.cookie.password: "${COOKIE_PASS}"
       opendistro_security.multitenancy.enabled: false
-      opendistro_security.openid.client_id: "kibana"
-      opendistro_security.openid.client_secret: "${OPENID_SECRET}"
-      opendistro_security.openid.scope: "openid"
-      opendistro_security.openid.connect_url: "https://roundtable.lsst.codes/.well-known/openid-configuration"
-      opendistro_security.openid.logout_url: "https://roundtable.lsst.codes/logout"
-      opendistro_security.openid.base_redirect_url: "https://roundtable.lsst.codes/"
       server.basePath: "/logs"
       server.rewriteBasePath: true
       server.host: "0.0.0.0"
@@ -65,17 +59,16 @@ opendistro-es:
     elasticsearchAccount:
       secret: "logging-accounts"
 
-    extraEnvs:
-      - name: OPENID_SECRET
-        valueFrom:
-          secretKeyRef:
-            name: "logging-accounts"
-            key: openid-secret
-
     ingress:
       enabled: true
       annotations:
         kubernetes.io/ingress.class: nginx
+        nginx.ingress.kubernetes.io/auth-method: "GET"
+        nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
+        nginx.ingress.kubernetes.io/auth-signin: "https://roundtable.lsst.codes/login"
+        nginx.ingress.kubernetes.io/auth-url: "https://roundtable.lsst.codes/auth?scope=exec:admin"
+        nginx.ingress.kubernetes.io/configuration-snippet: |
+          proxy_set_header X-Proxy-Roles "admin";
       hosts:
         - "roundtable.lsst.codes/logs"
 

--- a/docs/ops/logging/index.rst
+++ b/docs/ops/logging/index.rst
@@ -40,6 +40,7 @@ Fluentd gathers logs from each cluster node and forwards them to Elasticsearch.
    bootstrapping
    authentication
    troubleshooting
+   openid-connect
 
 .. seealso::
 

--- a/docs/ops/logging/openid-connect.rst
+++ b/docs/ops/logging/openid-connect.rst
@@ -1,0 +1,65 @@
+##############
+OpenID Connect
+##############
+
+Open Distro for Elasticsearch also supports OpenID Connect authentication, and we have tested it with Gafaelfawr.
+As documented in :doc:`Elasticsearch authentication <authentication>`, we are using proxy authentication instead.
+The primary reason is that this makes role management easier given that we want to assign the same role to every user.
+We add a request header at the NGINX ingress, and don't need to manage per-user roles.
+
+However, in case OpenID Connect becomes appealing for other reasons, here is a summary of how to reconfigure Open Distro for Elasticsearch to use it instead.
+
+Elasticsearch configuration
+===========================
+
+The Elasticsearch security configuration is defined by the ``logging-security-config`` secret.
+To use OpenID Connect instead, replace the ``proxy_auth_domain`` stanza in that configuration with the following:
+
+.. code-block:: yaml
+
+   openid_auth_domain:
+     http_enabled: true
+     transport_enabled: true
+     order: 1
+     http_authenticator:
+       type: openid
+       challenge: false
+       config:
+         enable_ssl: true
+         subject_key: sub
+         openid_connect_url: https://roundtable.lsst.codes/.well-known/openid-configuration
+
+This does not provide any source of role information, which means that users will not have access to any indices.
+To add roles, either manually map users to roles using the ``roles_mapping.yml`` file (see the `Open Distro for Elasticsearch security configuration <https://opendistro.github.io/for-elasticsearch-docs/docs/security/configuration/yaml/>`__), or add support to Gafaelfawr for populating a token attribute with a comma-separated list of Open Distro for Elasticsearch roles.
+
+Kibana configuration
+====================
+
+First, ensure that the ``kibana`` OpenID Connect client has an associated secret set in the ``oidc-server-secrets`` key of the Gafaelfawr secrets.
+See the `Gafaelfawr documentation <https://gafaelfawr.lsst.io/applications.html#using-openid-connect>`__ for more information.
+
+Then, add a matching ``openid-secret`` key to the ``logging`` Vault secret for Roundtable.
+
+Finally, add the following to ``values.yaml`` for the ``logging`` application to configure Kibana to use OpenID Connect:
+
+.. code-block:: yaml
+
+   kibana:
+     config:
+       opendistro_security.auth.type: "openid"
+       opendistro_security.openid.client_id: "kibana"
+       opendistro_security.openid.client_secret: "${OPENID_SECRET}"
+       opendistro_security.openid.scope: "openid"
+       opendistro_security.openid.connect_url: "https://roundtable.lsst.codes/.well-known/openid-configuration"
+       opendistro_security.openid.logout_url: "https://roundtable.lsst.codes/logout"
+       opendistro_security.openid.base_redirect_url: "https://roundtable.lsst.codes/"
+     extraEnvs:
+       - name: OPENID_SECRET
+         valueFrom:
+            secretKeyRef:
+              name: "logging-accounts"
+              key: openid-secret
+
+Also remove the old setting of ``opendistro_security.auth.type`` to ``proxy``, and remove the NGINX ingress annotations on the Kibana ingress.
+
+After syncing all the relevant applications and applying the Open Distro for Elasticsearch security configuration changes, Kibana should start using OpenID Connect authentication via Gafaelfawr.


### PR DESCRIPTION
Switch back to proxy authentication for Kibana since it's easier
to use with roles, but add tested documentation for how to use
OpenID Connect should it ever be useful in the future.

Revert to the default Gafaelfawr deployment, since we don't need
the new endpoint for proxy authentication.  We'll pick it up later
with the next regular Gafaelfawr release.