### PR TITLE
DM-27995: Reduce Kafka and Zookeeper to single replica

### DIFF
--- a/deployments/events/resources/kafka.yaml
+++ b/deployments/events/resources/kafka.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   kafka:
     version: 2.3.0
-    replicas: 3
+    replicas: 1
     resources:
       requests:
         memory: 2Gi
@@ -80,7 +80,7 @@ spec:
     metrics:
       lowercaseOutputName: true
   zookeeper:
-    replicas: 3
+    replicas: 1
     resources:
       requests:
         memory: 2Gi


### PR DESCRIPTION
There are crash loop back-offs restarting Kafka and Zookeeper pods; reducing the cluster size might help reset the cluster health.