### PR TITLE
[DM-27978] Switch from nginx-ingress to ingress-nginx

### DIFF
--- a/deployments/argo-cd/patches/argocd-cm.yaml
+++ b/deployments/argo-cd/patches/argocd-cm.yaml
@@ -45,6 +45,9 @@ data:
     # For the cert-manager chart
     - url: https://charts.jetstack.io
       name: jetstack
+    # For the ingress-nginx chart
+    - url: https://kubernetes.github.io/ingress-nginx/
+      name: ingress-nginx
     # For Strimzi (Kafka)
     - url: https://strimzi.io/charts/
       name: strimzi

--- a/deployments/argo-cd/patches/argocd-cm.yaml
+++ b/deployments/argo-cd/patches/argocd-cm.yaml
@@ -9,7 +9,7 @@ data:
   dex.config: |
     connectors:
       # Auth using GitHub.
-      # See https://github.com/dexidp/dex/blob/master/Documentation/connectors/github.md
+      # See https://dexidp.io/docs/connectors/github/
       # For example, we can authorize only members of certain teams in orgs.
       - type: github
         id: github

--- a/deployments/ingress-nginx/Chart.yaml
+++ b/deployments/ingress-nginx/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: ingress-nginx
+version: 1.0.0
+dependencies:
+- name: ingress-nginx
+  version: 3.19.0
+  repository: https://kubernetes.github.io/ingress-nginx

--- a/deployments/ingress-nginx/README.md
+++ b/deployments/ingress-nginx/README.md
@@ -1,0 +1,5 @@
+# ingress-nginx
+
+- Status: ![](https://cd.roundtable.lsst.codes/api/badge?name=ingress-inginx)
+- Dashboard: https://cd.roundtable.lsst.codes/applications/ingress-nginx
+- Docs: https://roundtable.lsst.io/ops/ingress-nginx

--- a/deployments/ingress-nginx/values.yaml
+++ b/deployments/ingress-nginx/values.yaml
@@ -1,4 +1,4 @@
-nginx-ingress:
+ingress-nginx:
   controller:
     config:
       compute-full-forwarded-for: "true"

--- a/deployments/logging/templates/kibana-networkpolicy.yaml
+++ b/deployments/logging/templates/kibana-networkpolicy.yaml
@@ -13,10 +13,10 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
-              app: nginx-ingress
+              app: ingress-nginx
           podSelector:
             matchLabels:
-              app: nginx-ingress
+              app: ingress-nginx
               component: controller
       ports:
         - protocol: TCP

--- a/deployments/nginx-ingress/Chart.yaml
+++ b/deployments/nginx-ingress/Chart.yaml
@@ -1,3 +1,0 @@
-apiVersion: v1
-name: nginx-ingress
-version: 1.0.0

--- a/deployments/nginx-ingress/README.md
+++ b/deployments/nginx-ingress/README.md
@@ -1,5 +1,0 @@
-# nginx-ingress
-
-- Status: ![](https://cd.roundtable.lsst.codes/api/badge?name=nginx-ingress)
-- Dashboard: https://cd.roundtable.lsst.codes/applications/nginx-ingress
-- Docs: https://roundtable.lsst.io/ops/nginx-ingress

--- a/deployments/nginx-ingress/requirements.yaml
+++ b/deployments/nginx-ingress/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-- name: nginx-ingress
-  version: 1.41.3
-  repository: https://kubernetes-charts.storage.googleapis.com

--- a/deployments/security/kustomization.yaml
+++ b/deployments/security/kustomization.yaml
@@ -3,5 +3,5 @@ kind: Kustomization
 
 resources:
   - resources/cert-manager.yaml
-  - resources/nginx-ingress.yaml
+  - resources/ingress-nginx.yaml
   - resources/vault.yaml

--- a/deployments/security/resources/ingress-nginx.yaml
+++ b/deployments/security/resources/ingress-nginx.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: nginx-ingress
+  name: ingress-nginx
   labels:
-    app: nginx-ingress
+    app: ingress-nginx
 spec:
   finalizers:
     - kubernetes
@@ -11,14 +11,14 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: nginx-ingress
+  name: ingress-nginx
 spec:
   destination:
-    namespace: nginx-ingress
+    namespace: ingress-nginx
     server: https://kubernetes.default.svc
   project: default
   source:
-    path: deployments/nginx-ingress
+    path: deployments/ingress-nginx
     repoURL: https://github.com/lsst-sqre/roundtable
     targetRevision: HEAD
   syncPolicy:
@@ -31,7 +31,7 @@ spec:
     # The Cluster IP is immutable; so we shouldn't look at differences there.
     # If left out, we see the error message:
     #   kubectl failed exit status 1: The Service
-    #   "nginx-ingress-controller-metrics" is invalid: spec.clusterIP: Invalid
+    #   "ingress-nginx-controller-metrics" is invalid: spec.clusterIP: Invalid
     #   value: "": field is immutable
     # Credit: https://gist.github.com/kyohmizu/8ebc9c3dcadad6f22dd0246caad9b951
     - /spec/clusterIP

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -149,7 +149,7 @@ rst_epilog = """
 .. _Grafana: https://grafana.com/grafana
 .. _lsst-sqre GitHub organization: https://github.com/lsst-sqre
 .. _roundtable-ops team: https://github.com/orgs/lsst-sqre/teams/roundtable-ops
-.. _httpie: https://httpie.org
+.. _httpie: https://httpie.io
 .. _Strimzi: https://strimzi.io
 .. _Sealed Secrets: https://github.com/bitnami-labs/sealed-secrets
 .. _Vault: https://www.vaultproject.io/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,9 +96,9 @@ rst_epilog = """
    :target: https://cd.roundtable.lsst.codes/applications/argo-cd
    :alt: Argo CD app status
 
-.. |nginx-ingress-status| image:: https://cd.roundtable.lsst.codes/api/badge?name=nginx-ingress
-   :target: https://cd.roundtable.lsst.codes/applications/nginx-ingress
-   :alt: nginx-ingress app status
+.. |ingress-nginx-status| image:: https://cd.roundtable.lsst.codes/api/badge?name=ingress-nginx
+   :target: https://cd.roundtable.lsst.codes/applications/ingress-nginx
+   :alt: ingress-nginx app status
 
 .. |cert-manager-status| image:: https://cd.roundtable.lsst.codes/api/badge?name=cert-manager
    :target: https://cd.roundtable.lsst.codes/applications/cert-manager

--- a/docs/ops/argo-cd/argocd-github-sso.rst
+++ b/docs/ops/argo-cd/argocd-github-sso.rst
@@ -24,7 +24,7 @@ Access can be limited to members of organizations listed in the GitHub SSO of th
 Currently only members of the `lsst-sqre GitHub organization`_ can log in.
 
 Dex, the OIDC component used by Argo CD, also supports limited access by GitHub team.
-See the `Authenticating with GitHub page <https://github.com/dexidp/dex/blob/master/Documentation/connectors/github.md>`__ in the Dex documentation.
+See the `Authentication through GitHub page <https://dexidp.io/docs/connectors/github/>`__ in the Dex documentation.
 
 .. _`SSO Configuration`: https://argoproj.github.io/argo-cd/operator-manual/user-management/#sso
 .. _`argocd-cm.yaml patch`: https://github.com/lsst-sqre/roundtable/blob/master/deployments/argo-cd/patches/argocd-cm.yaml

--- a/docs/ops/cert-manager/index.rst
+++ b/docs/ops/cert-manager/index.rst
@@ -16,4 +16,4 @@ cert-manager app deployment guide
 
 .. rubric:: Overview
 
-This Argo CD Application deploys and configures `cert-manager <https://cert-manager.io>`__ from its `Helm chart repository <https://hub.helm.sh/charts/jetstack/cert-manager>`__.
+This Argo CD Application deploys and configures `cert-manager <https://cert-manager.io>`__ from its `Helm chart repository <https://artifacthub.io/packages/helm/jetstack/cert-manager>`__.

--- a/docs/ops/events/cluster-config-overview.rst
+++ b/docs/ops/events/cluster-config-overview.rst
@@ -29,14 +29,14 @@ Listeners and authentication
 ============================
 
 The cluster has an internal listener on port ``9093``, which supports mutual TLS authentication between the client and brokers.
-See `Creating a Kafka user with mutual TLS authentication <https://strimzi.io/docs/operators/latest/using.html#tls_client_authentication_5>`_ for details on how create a ``KafkaUser`` resource and use the corresponding Kubernetes ``Secret`` resource with client TLS certificates.
+See `Creating a Kafka user with mutual TLS authentication <https://strimzi.io/docs/operators/latest/using.html#tls_client_authentication>`_ for details on how create a ``KafkaUser`` resource and use the corresponding Kubernetes ``Secret`` resource with client TLS certificates.
 
 Authorization
 =============
 
 Authorization is enabled for this cluster.
 This means that that Kafka clients need a corresponding ``KafkaUser`` resource with corresponding access permissions.
-See the `Strimzi Authorization documentation <https://strimzi.io/docs/latest/#ref-kafka-authorization-deployment-configuration-kafka>`_ for more information.
+See the `Strimzi Authorization documentation <https://strimzi.io/docs/operators/latest/using.html#assembly-securing-kafka-clients-str>`_ for more information.
 
 Kafka configuration
 ===================

--- a/docs/ops/gke/gke-cluster-setup.rst
+++ b/docs/ops/gke/gke-cluster-setup.rst
@@ -27,7 +27,7 @@ Stackdriver monitoring
 Stackdriver Kubernetes monitoring is **enabled** and Legacy Stackdriver Logging and Legacy Stackdriver Monitoring are **disabled**.
 
 We use Stackdriver for logs.
-See the `Stackdriver Kubernetes Engine Monitoring <https://cloud.google.com/monitoring/kubernetes-engine/>`_ documentation for more information.
+See the `Stackdriver Kubernetes Engine Monitoring <https://cloud.google.com/stackdriver/docs/solutions/gke>`_ documentation for more information.
 
 Istio
 =====

--- a/docs/ops/gke/howto-connect-to-gke.rst
+++ b/docs/ops/gke/howto-connect-to-gke.rst
@@ -25,7 +25,7 @@ You can use the ``kubectl`` command-line tool to access the Roundtable cluster.
 Follow Google's `Configuring cluster access for kubectl <https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl>`_ page.
 Briefly, the steps are:
 
-1. Install the `Cloud SDK <https://cloud.google.com/sdk/install>`_.
+1. Install the `Cloud SDK <https://cloud.google.com/sdk/docs/install>`_.
 
 2. Set the project:
 

--- a/docs/ops/index.rst
+++ b/docs/ops/index.rst
@@ -16,8 +16,8 @@ Although this documentation is openly available, application developers shouldn'
    cert-manager/index
    events/index
    gafaelfawr/index
+   ingress-nginx/index
    logging/index
-   nginx-ingress/index
    prometheus/index
    sealed-secrets/index
    strimzi/index

--- a/docs/ops/ingress-nginx/index.rst
+++ b/docs/ops/ingress-nginx/index.rst
@@ -1,14 +1,14 @@
 ##################################
-nginx-ingress app deployment guide
+ingress-nginx app deployment guide
 ##################################
 
 .. list-table::
    :widths: 10,40
 
    * - Deployment
-     - |nginx-ingress-status|
+     - |ingress-nginx-status|
    * - Edit on GitHub
-     - `/deployments/nginx-ingress <https://github.com/lsst-sqre/roundtable/tree/master/deployments/nginx-ingress>`__
+     - `/deployments/ingress-nginx <https://github.com/lsst-sqre/roundtable/tree/master/deployments/ingress-nginx>`__
    * - Type
      - Helm_
    * - Parent app
@@ -16,11 +16,11 @@ nginx-ingress app deployment guide
 
 .. rubric:: Overview
 
-This Argo CD Application deploys and configures `nginx-ingress <https://github.com/kubernetes/ingress-nginx>`__ from the `stable Helm chart repository <https://github.com/helm/charts/tree/master/stable/nginx-ingress>`__.
+This Argo CD Application deploys and configures `ingress-nginx <https://github.com/kubernetes/ingress-nginx>`__ from its `Helm chart repository <https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx>`__.
 
 .. rubric:: Upgrading
 
-While the nginx-ingress Helm chart tries to do a seamless upgrade, there is a possibility something could go wrong and bring down the ingress.
+While the ingress-nginx Helm chart tries to do a seamless upgrade, there is a possibility something could go wrong and bring down the ingress.
 If this happens, the normal `Argo CD dashboard <https://cd.roundtable.lsst.codes/>`__ will become inaccessible.
 Some care is therefore required when updating to a new version of this Helm chart.
 
@@ -30,9 +30,9 @@ You will then hopefully be able to use the normal Argo CD dashboard to fix any p
 
 .. rubric:: Ingress public IP
 
-The nginx-ingress needs to bind to a stable public IP address which matches the DNS entries for Roundtable configured in AWS Route 53.
+The ingress-nginx needs to bind to a stable public IP address which matches the DNS entries for Roundtable configured in AWS Route 53.
 In GCE, this is done by reserving a static IP address for the correct region in the underlying Google Cloud account, and then configuring the ingress to request that IP address.
-The latter step is done in `the values file for nginx-ingress <https://github.com/lsst-sqre/roundtable/blob/master/deployments/nginx-ingress/values.yaml>`__ by setting ``controller.service.loadBalacerIP``.
+The latter step is done in `the values file for ingress-nginx <https://github.com/lsst-sqre/roundtable/blob/master/deployments/ingress-nginx/values.yaml>`__ by setting ``controller.service.loadBalacerIP``.
 
 If there is ever a need to reserve a new static IP address in GCP, see `the Google documentation <https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address>`__.
 If we have lost the external IP and need to allocate a new one, it is possible to promote whatever ephemeral IP address is currently bound to Roundtable to a reserved static IP.

--- a/docs/ops/prometheus/grafana-github-sso.rst
+++ b/docs/ops/prometheus/grafana-github-sso.rst
@@ -11,8 +11,8 @@ GitHub OAuth app and grafana.ini configuration
 The GitHub OAuth app is called `LSST Roundtable Monitor <https://github.com/organizations/lsst-sqre/settings/applications/1133398>`_ and is owned by the `lsst-sqre GitHub organization`_ organization.
 
 GitHub SSO is primarily configured through the `values.yaml file`_.
-The Grafana Helm chart translates YAML into the standard `grafana.ini configuration file <https://grafana.com/docs/installation/configuration/>`_.
-See the Grafana documentation on `GitHub OAuth2 Authentication <https://grafana.com/docs/auth/github/>`_, specifically.
+The Grafana Helm chart translates YAML into the standard `grafana.ini configuration file <https://grafana.com/docs/grafana/latest/installation/configuration/>`_.
+See the Grafana documentation on `GitHub OAuth2 Authentication <https://grafana.com/docs/grafana/latest/auth/github/>`_, specifically.
 
 The only part of the configuration not included in the `values.yaml file`_ is the GitHub OAuth client secret.
 This value is obtained from an environment variable override mounted from the ``grafana-env`` secret resource (see the ``envFromSecret`` field in the `values.yaml file`_).

--- a/docs/ops/security/index.rst
+++ b/docs/ops/security/index.rst
@@ -20,7 +20,7 @@ The ``security`` app is responsible for deploying security services for Roundtab
 It follows the `app of apps <https://argoproj.github.io/argo-cd/operator-manual/cluster-bootstrapping/#app-of-apps-pattern>`__ pattern.
 It deploys:
 
-- :doc:`nginx-ingress <../nginx-ingress/index>` for shared ingress.
+- :doc:`ingress-nginx <../ingress-nginx/index>` for shared ingress.
 - :doc:`cert-manager <../cert-manager/index>` for Let's-Encrypt-provided TLS certificates.
 - :doc:`vault <../vault/index>` for the Vault secret service.
 


### PR DESCRIPTION
The nginx-ingress chart is no longer maintained in favor of an
ingress-nginx chart maintained by the same team as the ingress
code itself.  Switch Roundtable to the latest version of that
chart.  Switch the chart to Helm v3 in the process, since this is
required by the upstream chart.