### PR TITLE
[DM-27978] Add new stable Helm chart repository

### DIFF
--- a/deployments/argo-cd/patches/argocd-cm.yaml
+++ b/deployments/argo-cd/patches/argocd-cm.yaml
@@ -39,6 +39,9 @@ data:
     - url: https://github.com/lsst-sqre/ook.git
   # Non-standard Helm chart repositories.
   helm.repositories: |
+    # New default stable Helm chart repository
+    - url: https://charts.helm.sh/stable
+      name: stable
     # For the cert-manager chart
     - url: https://charts.jetstack.io
       name: jetstack

--- a/deployments/prometheus/requirements.yaml
+++ b/deployments/prometheus/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: prometheus-operator
     version: 9.3.2
-    repository: https://kubernetes-charts.storage.googleapis.com
+    repository: https://charts.helm.sh/stable


### PR DESCRIPTION
The default stable Helm chart repository has moved.  Add the new
location to Argo CD's chart repository list, and update the pointer
for the prometheus-operator chart.