### PR TITLE
[DM-27977] Replace prometheus with kube-prometheus-system

### DIFF
--- a/deployments/argo-cd/patches/argocd-cm.yaml
+++ b/deployments/argo-cd/patches/argocd-cm.yaml
@@ -57,6 +57,12 @@ data:
     # For Vault Secrets Operator
     - url: https://ricoberger.github.io/helm-charts/
       name: ricoberger
+    # For Prometheus
+    - url: https://prometheus-community.github.io/helm-charts
+      name: prometheus-community
+    # For the Grafana subchart for Prometheus
+    - url: https://grafana.github.io/helm-charts
+      name: grafana
     # SQuaRE charts
     - url: https://lsst-sqre.github.io/charts/
       name: lsst-sqre

--- a/deployments/kube-prometheus-stack/Chart.yaml
+++ b/deployments/kube-prometheus-stack/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: kube-prometheus-stack
+version: 1.0.0
+dependencies:
+  - name: kube-prometheus-stack
+    version: 13.1.1
+    repository: https://prometheus-community.github.io/helm-charts

--- a/deployments/kube-prometheus-stack/README.md
+++ b/deployments/kube-prometheus-stack/README.md
@@ -1,0 +1,5 @@
+# kube-prometheus-stack
+
+- Status: ![](https://cd.roundtable.lsst.codes/api/badge?name=kube-prometheus-stack)
+- Dashboard: https://cd.roundtable.lsst.codes/applications/kube-prometheus-stack
+- Docs: https://roundtable.lsst.io/ops/kube-prometheus-stack

--- a/deployments/kube-prometheus-stack/templates/vault-secret.yaml
+++ b/deployments/kube-prometheus-stack/templates/vault-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: grafana-env
+spec:
+  path: secret/k8s_operator/roundtable/grafana
+  type: Opaque

--- a/deployments/kube-prometheus-stack/values.yaml
+++ b/deployments/kube-prometheus-stack/values.yaml
@@ -1,0 +1,51 @@
+prometheus-operator:
+  grafana:
+    ingress:
+      enabled: true
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+        cert-manager.io/cluster-issuer: "letsencrypt-issuer"
+      hosts:
+        - monitoring.roundtable.lsst.codes
+      tls:
+        secretName: grafana-ingress-tls
+        hosts:
+          - monitoring.roundtable.lsst.codes
+    service:
+      persistence:
+        enabled: true
+        size: "10Gi"
+        storageClassName: "standard"
+      # Secret resource that contains environment variables for e.g.
+      # the GitHub auth client secret.
+      envFromSecret: "grafana-env"
+      grafana.ini:
+        server:
+          root_url: "https://monitoring.roundtable.lsst.codes"
+        auth.github:
+          enabled: true
+          allow_sign_up: true
+          client_id: "73863e794667b769be29"
+          scopes: "user:email,read:org"
+          auth_url: "https://github.com/login/oauth/authorize"
+          token_url: "https://github.com/login/oauth/access_token"
+          api_url: "https://api.github.com/user"
+          # Comma-delimited list to GitHub teams
+          # 3408969: @lsst-sqre/roundtable-ops
+          team_ids: "3408969"
+          # Space-delimited list of GitHub organization
+          allowed_organizations: "lsst-sqre"
+  prometheusOperator:
+    admissionWebhooks:
+      enabled: false
+  prometheus:
+    prometheusSpec:
+      storageSpec:
+        volumeClaimTemplate:
+          # Request SSD persistent volume for Prometheus data.
+          spec:
+            storageClassName: "faster"
+            accessModes: ["ReadWriteOnce"]
+            resources:
+              requests:
+                storage: "10Gi"

--- a/deployments/roundtable/kustomization.yaml
+++ b/deployments/roundtable/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   # Applications
   - resources/argo-cd.yaml
   - resources/gafaelfawr.yaml
+  - resources/kube-prometheus-stack.yaml
   - resources/strimzi.yaml
   - resources/events-dev.yaml
   - resources/events.yaml

--- a/deployments/roundtable/resources/kube-prometheus-stack.yaml
+++ b/deployments/roundtable/resources/kube-prometheus-stack.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-prometheus-stack
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kube-prometheus-stack
+spec:
+  destination:
+    namespace: kube-prometheus-stack
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: deployments/kube-prometheus-stack
+    repoURL: https://github.com/lsst-sqre/roundtable
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,8 +104,8 @@ rst_epilog = """
    :target: https://cd.roundtable.lsst.codes/applications/cert-manager
    :alt: cert-manager app status
 
-.. |prometheus-status| image:: https://cd.roundtable.lsst.codes/api/badge?name=prometheus
-   :target: https://cd.roundtable.lsst.codes/applications/prometheus
+.. |kube-prometheus-stack-status| image:: https://cd.roundtable.lsst.codes/api/badge?name=kube-prometheus-stack
+   :target: https://cd.roundtable.lsst.codes/applications/kube-prometheus-stack
    :alt: Prometheus app status
 
 .. |strimzi-status| image:: https://cd.roundtable.lsst.codes/api/badge?name=strimzi

--- a/docs/ops/index.rst
+++ b/docs/ops/index.rst
@@ -17,8 +17,8 @@ Although this documentation is openly available, application developers shouldn'
    events/index
    gafaelfawr/index
    ingress-nginx/index
+   kube-prometheus-stack/index
    logging/index
-   prometheus/index
    sealed-secrets/index
    strimzi/index
    vault/index

--- a/docs/ops/kube-prometheus-stack/grafana-github-sso.rst
+++ b/docs/ops/kube-prometheus-stack/grafana-github-sso.rst
@@ -16,21 +16,9 @@ See the Grafana documentation on `GitHub OAuth2 Authentication <https://grafana.
 
 The only part of the configuration not included in the `values.yaml file`_ is the GitHub OAuth client secret.
 This value is obtained from an environment variable override mounted from the ``grafana-env`` secret resource (see the ``envFromSecret`` field in the `values.yaml file`_).
-The secret configuration:
+This secret, in turn, is created from a ``VaultSecret`` that pulls the secret information from the ``grafana`` secret in the Roundtable Vault secret tree.
 
-.. code-block:: yaml
-
-   apiVersion: v1
-   kind: Secret
-   metadata:
-     name: grafana-env
-   type: Opaque
-   stringData:
-     GF_AUTH_GITHUB_CLIENT_SECRET: "<client-secret>"
-
-Deploy this secret into the ``prometheus`` namespace.
-
-.. _`values.yaml file`: https://github.com/lsst-sqre/roundtable/blob/master/deployments/prometheus/values.yaml
+The Vault secret should contain one key, ``GF_AUTH_GITHUB_CLIENT_SECRET``, the value of which is the GitHub OAuth client secret.
 
 Organization and team-based access
 ==================================

--- a/docs/ops/kube-prometheus-stack/index.rst
+++ b/docs/ops/kube-prometheus-stack/index.rst
@@ -1,14 +1,14 @@
-###############################
-prometheus app deployment guide
-###############################
+##########################################
+kube-prometheus-stack app deployment guide
+##########################################
 
 .. list-table::
    :widths: 10,40
 
    * - Deployment
-     - |prometheus-status|
+     - |kube-prometheus-stack-status|
    * - Edit on GitHub
-     - `/deployments/prometheus <https://github.com/lsst-sqre/roundtable/tree/master/deployments/prometheus>`__
+     - `/deployments/kube-prometheus-stack <https://github.com/lsst-sqre/roundtable/tree/master/deployments/kube-prometheus-stack>`__
    * - Type
      - Helm_
    * - Parent app
@@ -18,7 +18,7 @@ prometheus app deployment guide
 
 .. rubric:: Overview
 
-This Argo CD Application deploys and configures a Prometheus_ monitoring stack based on the `prometheus-operator Helm chart <https://github.com/helm/charts/tree/master/stable/prometheus-operator>`__.
+This Argo CD Application deploys and configures a Prometheus_ monitoring stack based on the `kube-prometheus-stack Helm chart <https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack>`__.
 The Grafana dashboard is online at https://monitoring.roundtable.lsst.codes.
 
 .. rubric:: Upgrading

--- a/docs/ops/roundtable/index.rst
+++ b/docs/ops/roundtable/index.rst
@@ -26,7 +26,7 @@ It deploys:
 
   - :doc:`argo-cd <../argo-cd/index>` for continuous delivery of Roundtable apps with Argo CD.
   - :doc:`gafaelfawr <../gafaelfawr/index>` for OpenID Connect web authentication.
-  - :doc:`prometheus <../prometheus/index>` for the Kubernetes-native monitoring stack (Prometheus Operator, Prometheus, and Grafana).
+  - :doc:`kube-prometheus-stack <../kube-prometheus-stack/index>` for the Kubernetes-native monitoring stack (Prometheus Operator, Prometheus, and Grafana).
   - :doc:`vault-secrets-operator <../vault-secrets-operator/index>` to retrieve secrets from Vault and store them as Kubernetes secrets.
 
 This app depends on the :doc:`security <../security/index>` app, which provides secret management facilities and ingress.


### PR DESCRIPTION
The older Prometheus chart has been deprecated and the new recommended
Helm chart is kube-prometheus-system.  Replace the old Prometheus
configuration with the new chart.  Since the data from the current
system is not currently that significant, this uninstalls the old
Prometheus install and creates a new one rather than trying to preserve
and move the persistent volumes.

Add a VaultSecret for the Grafana GitHub OAuth 2 secret, which was
previously using a manually-created secret.  (The relevant secret has
already been stored in Vault.)