### PR TITLE
[DM-27977] Fix Argo CD ServiceMonitor annotations

### DIFF
--- a/deployments/argo-cd/resources/argocd-metrics.yaml
+++ b/deployments/argo-cd/resources/argocd-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   name: argocd-metrics
   labels:
     # Match Prometheus's serviceMonitorSelector.matchLabels
-    release: prometheus
+    release: kube-prometheus-stack
 spec:
   selector:
     matchLabels:

--- a/deployments/argo-cd/resources/argocd-repo-server-metrics.yaml
+++ b/deployments/argo-cd/resources/argocd-repo-server-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   name: argocd-repo-server-metrics
   labels:
     # Match Prometheus's serviceMonitorSelector.matchLabels
-    release: prometheus
+    release: kube-prometheus-stack
 spec:
   selector:
     matchLabels:

--- a/deployments/argo-cd/resources/argocd-server-metrics.yaml
+++ b/deployments/argo-cd/resources/argocd-server-metrics.yaml
@@ -4,7 +4,7 @@ metadata:
   name: argocd-server-metrics
   labels:
     # Match Prometheus's serviceMonitorSelector.matchLabels
-    release: prometheus
+    release: kube-prometheus-stack
 spec:
   selector:
     matchLabels:

--- a/deployments/kube-prometheus-stack/values.yaml
+++ b/deployments/kube-prometheus-stack/values.yaml
@@ -50,9 +50,6 @@ kube-prometheus-stack:
 
   prometheus:
     prometheusSpec:
-      serviceMonitorNamespaceSelector:
-        all: true
-
       storageSpec:
         volumeClaimTemplate:
           # Request SSD persistent volume for Prometheus data.


### PR DESCRIPTION
Fix the labels so that Argo CD metrics are picked up and revert
the change to the namespace selector, which appears to not be
needed.