### PR TITLE
Remove weekly Renovate schedule, bump concurrency

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
-    "config:base", "schedule:weekly"
-  ]
+    "config:base"
+  ],
+  "prConcurrentLimit": 5
 }


### PR DESCRIPTION
Renovate seems to now be defaulting to 2 concurrent PRs, so bump
that to five to try to process more updates.  Remove the weekly
schedule for now to get through the backlog.