### PR TITLE
Update Renovate schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "extends": [
     "config:base"
   ],
-  "prConcurrentLimit": 5
+  "prConcurrentLimit": 5,
+  "schedule": [
+    "before 6am on Monday"
+  ]
 }


### PR DESCRIPTION
Rather than returning to a weekly schedule, which only gives
Renovate three runs to open its PRs, give it until 6am on Monday
morning to open its PRs.  Since it's only willing to open one or
two an hour, this ensures it can reach the PR limit of 5.