### PR TITLE
Switch to Helm 3 for all wrapper charts

### DIFF
--- a/deployments/cert-manager/Chart.yaml
+++ b/deployments/cert-manager/Chart.yaml
@@ -1,3 +1,7 @@
-apiVersion: v1
+apiVersion: v2
 name: cert-manager
 version: 1.0.0
+dependencies:
+- name: cert-manager
+  version: v1.2.0
+  repository: https://charts.jetstack.io

--- a/deployments/cert-manager/requirements.yaml
+++ b/deployments/cert-manager/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-- name: cert-manager
-  version: v1.2.0
-  repository: https://charts.jetstack.io

--- a/deployments/gafaelfawr/Chart.yaml
+++ b/deployments/gafaelfawr/Chart.yaml
@@ -1,3 +1,7 @@
 apiVersion: v2
 name: gafaelfawr
 version: 1.0.0
+dependencies:
+  - name: gafaelfawr
+    version: 1.5.6
+    repository: https://lsst-sqre.github.io/charts/

--- a/deployments/gafaelfawr/requirements.yaml
+++ b/deployments/gafaelfawr/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-  - name: gafaelfawr
-    version: 1.5.6
-    repository: https://lsst-sqre.github.io/charts/

--- a/deployments/logging/Chart.yaml
+++ b/deployments/logging/Chart.yaml
@@ -1,3 +1,10 @@
-apiVersion: v1
+apiVersion: v2
 name: logging
 version: 0.0.1
+dependencies:
+- name: opendistro-es
+  version: 1.4.1
+  repository: https://lsst-sqre.github.io/charts/
+- name: fluentd-elasticsearch
+  version: 9.6.2
+  repository: https://kiwigrid.github.io

--- a/deployments/logging/requirements.yaml
+++ b/deployments/logging/requirements.yaml
@@ -1,7 +1,0 @@
-dependencies:
-- name: opendistro-es
-  version: 1.4.1
-  repository: https://lsst-sqre.github.io/charts/
-- name: fluentd-elasticsearch
-  version: 9.6.2
-  repository: https://kiwigrid.github.io

--- a/deployments/strimzi/Chart.yaml
+++ b/deployments/strimzi/Chart.yaml
@@ -1,3 +1,7 @@
-apiVersion: v1
+apiVersion: v2
 name: strimzi
 version: 1.0.0
+dependencies:
+  - name: strimzi-kafka-operator
+    version: 0.14.0
+    repository: https://strimzi.io/charts/

--- a/deployments/strimzi/requirements.yaml
+++ b/deployments/strimzi/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-  - name: strimzi-kafka-operator
-    version: 0.14.0
-    repository: https://strimzi.io/charts/

--- a/deployments/vault-secrets-operator/Chart.yaml
+++ b/deployments/vault-secrets-operator/Chart.yaml
@@ -1,3 +1,7 @@
-apiVersion: v1
+apiVersion: v2
 name: vault-secrets-operator
 version: 1.0.0
+dependencies:
+  - name: vault-secrets-operator
+    version: 1.13.0
+    repository: https://ricoberger.github.io/helm-charts/

--- a/deployments/vault-secrets-operator/requirements.yaml
+++ b/deployments/vault-secrets-operator/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-  - name: vault-secrets-operator
-    version: 1.13.0
-    repository: https://ricoberger.github.io/helm-charts/


### PR DESCRIPTION
I think this is the reason why some charts won't update in the
Argo CD dashboard.  Try using Helm 3 for everything, following a
change we already made on Phalanx.