### PR TITLE
[DM-28993] Bump service versions

### DIFF
--- a/deployments/checkerboard/kustomization.yaml
+++ b/deployments/checkerboard/kustomization.yaml
@@ -4,5 +4,5 @@ kind: Kustomization
 namespace: events
 
 resources:
-  - github.com/lsst-sqre/checkerboard.git//manifests/base?ref=0.3.0
+  - github.com/lsst-sqre/checkerboard.git//manifests/base?ref=0.3.1
   - resources/secret.yaml

--- a/deployments/neophile/Chart.yaml
+++ b/deployments/neophile/Chart.yaml
@@ -3,5 +3,5 @@ name: neophile
 version: 1.0.0
 dependencies:
   - name: neophile
-    version: 0.2.0
+    version: 0.2.1
     repository: https://lsst-sqre.github.io/charts/

--- a/deployments/ook/kustomization.yaml
+++ b/deployments/ook/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: events
 
 resources:
   - resources/vaultsecret.yaml
-  - github.com/lsst-sqre/ook.git//manifests/base?ref=0.3.0
+  - github.com/lsst-sqre/ook.git//manifests/base?ref=0.3.1
 
 patches:
   - patches/configmap.yaml

--- a/deployments/safirdemo/kustomization.yaml
+++ b/deployments/safirdemo/kustomization.yaml
@@ -3,9 +3,5 @@ kind: Kustomization
 
 namespace: events
 
-images:
-  - name: lsstsqre/safirdemo
-    newTag: 0.1.1
-
 resources:
-  - github.com/lsst-sqre/safirdemo.git//manifests/base?ref=0.1.1
+  - github.com/lsst-sqre/safirdemo.git//manifests/base?ref=0.1.2

--- a/deployments/segwarides/kustomization.yaml
+++ b/deployments/segwarides/kustomization.yaml
@@ -4,5 +4,5 @@ kind: Kustomization
 namespace: events
 
 resources:
-  - github.com/lsst-sqre/segwarides.git//manifests/base?ref=0.4.1
+  - github.com/lsst-sqre/segwarides.git//manifests/base?ref=0.4.2
   - resources/secret.yaml


### PR DESCRIPTION
Install new versions of checkerboard, neophile, ook, safirdemo,
and segwarides to pick up refreshed dependencies.  The
segwarides Kustomize manifest now pins its Docker version to the
current release, so we don't need to do that in Roundtable.