### PR TITLE
DM-29879: Update LTD Keeper to 1.22.0

### DIFF
--- a/deployments/lsst-the-docs/kustomization.yaml
+++ b/deployments/lsst-the-docs/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 resources:
 - resources/keeper-sealedsecret.yaml
 - resources/cloudsql-sealedsecret.yaml
-- github.com/lsst-sqre/ltd-keeper.git//manifests?ref=1.21.0
+- github.com/lsst-sqre/ltd-keeper.git//manifests?ref=1.22.0
 - resources/keeper-ingress.yaml
 - github.com/lsst-sqre/ltd-dasher.git//manifests?ref=0.1.10
 


### PR DESCRIPTION
Update LTD Keeper to 1.22.0 to support a longer TTL for presigned build upload URLs to S3.