### PR TITLE
Create sqrbot (hubot) deployment

### DIFF
--- a/deployments/app-land/kustomization.yaml
+++ b/deployments/app-land/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - resources/ltdevents.yaml
   - resources/neophile.yaml
   - resources/safirdemo.yaml
+  - resources/sqrbot.yaml
   - resources/sqrbot-jr.yaml
   - resources/sqrbot-jsick.yaml
   - resources/templatebot.yaml

--- a/deployments/app-land/resources/sqrbot.yaml
+++ b/deployments/app-land/resources/sqrbot.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sqrbot
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sqrbot
+spec:
+  destination:
+    namespace: sqrbot
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: deployments/sqrbot
+    repoURL: https://github.com/lsst-sqre/roundtable
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true

--- a/deployments/sqrbot/kustomization.yaml
+++ b/deployments/sqrbot/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: sqrbot
+
+resources:
+  - resources/vaultsecret.yaml
+  - resources/deployment.yaml

--- a/deployments/sqrbot/resources/deployment.yaml
+++ b/deployments/sqrbot/resources/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sqrbot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: sqrbot
+  template:
+    metadata:
+      labels:
+        name: sqrbot
+    spec:
+      containers:
+        - name: sqrbot
+          imagePullPolicy: "Always"
+          image: "lsstsqre/sqrbot:latest"
+          env:
+            - name: HUBOT_NAME
+              value: "sqrbot"
+            - name: HUBOT_SLACK_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: sqrbot
+                  key: slack-token
+            - name: HUBOT_GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: sqrbot
+                  key: github-token
+            - name: HUBOT_GITHUB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: sqrbot
+                  key: github-password
+            - name: HUBOT_GITHUB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: sqrbot
+                  key: github-user
+            # If you specify these everything gets screwed up
+            #  if the username/password are incorrect.
+            - name: LSST_JIRA_USER
+              valueFrom:
+                secretKeyRef:
+                  name: sqrbot
+                  key: jira-user
+            - name: LSST_JIRA_PWD
+              valueFrom:
+                secretKeyRef:
+                  name: sqrbot
+                  key: jira-password
+            - name: HUBOT_LOG_LEVEL
+              value: info

--- a/deployments/sqrbot/resources/vaultsecret.yaml
+++ b/deployments/sqrbot/resources/vaultsecret.yaml
@@ -1,0 +1,8 @@
+# Vault secret reference for the ook deployments
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: sqrbot
+spec:
+  path: secret/k8s_operator/roundtable/sqrbot
+  type: Opaque


### PR DESCRIPTION
This deployment is fairly simple and is based entirely off manifests in roundtable, without referencing the https://github.com/lsst-sqre/sqrbot repo. The original secrets from the api.lsst.codes deployment are now in Vault under secret/k8s_operator/roundtable/sqrbot.