### PR TITLE
Use DM-33317 v of strimzi-registry-operator

### DIFF
--- a/deployments/events/kustomization.yaml
+++ b/deployments/events/kustomization.yaml
@@ -1,11 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+images:
+  - name: lsstsqre/strimzi-registry-operator
+    newTag: tickets-DM-33317
+
 resources:
   - resources/kafka.yaml
   # Schema Registry
   - resources/schemaregistry-user.yaml
-  - github.com/lsst-sqre/strimzi-registry-operator.git//manifests?ref=0.3.0
+  - github.com/lsst-sqre/strimzi-registry-operator.git//manifests?ref=tickets/DM-33317
   - resources/schemaregistry.yaml
   - resources/schemas-topic.yaml
   # Kafka topics

--- a/deployments/events/patches/strimzi-registry-operator-deployment.yaml
+++ b/deployments/events/patches/strimzi-registry-operator-deployment.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: strimzi-registry-operator
+  spec:
+    template:
+      spec:
+        containers:
+          - name: operator
+            env:
+              - name: SSR_CLUSTER_NAME
+                value: events
+              - name: SSR_NAMESPACE
+                value: events

--- a/deployments/events/resources/schemaregistry.yaml
+++ b/deployments/events/resources/schemaregistry.yaml
@@ -2,4 +2,6 @@ apiVersion: roundtable.lsst.codes/v1beta1
 kind: StrimziSchemaRegistry
 metadata:
   name: schemaregistry
-spec: {}
+spec:
+  strimzi-version: v1beta1
+  listener: internal


### PR DESCRIPTION
Along with a new container build, this ticket-branch-based version also uses a newer Kubernetes API version in the CRDs.