### PR TITLE
DM-33317: Spin down sqrbot-jsick app and have renovate ignore them

### DIFF
--- a/deployments/app-land/kustomization.yaml
+++ b/deployments/app-land/kustomization.yaml
@@ -14,9 +14,11 @@ resources:
   - resources/safirdemo.yaml
   - resources/sqrbot.yaml
   - resources/sqrbot-jr.yaml
-  - resources/sqrbot-jsick.yaml
   - resources/templatebot.yaml
-  # - resources/templatebot-jsick.yaml
   - resources/segwarides.yaml
   - resources/ook.yaml
   - resources/rubintv.yaml
+  # Test versions of apps; to re-enable these also re-enable the events API
+  # for the sqrbot-jsick Slack API (via the Slack app admin API).
+  # - resources/sqrbot-jsick.yaml
+  # - resources/templatebot-jsick.yaml

--- a/deployments/events/kustomization.yaml
+++ b/deployments/events/kustomization.yaml
@@ -28,4 +28,7 @@ resources:
   - resources/ltdevents-user.yaml
   - resources/ook-user.yaml
 
+patches:
+  - patches/strimzi-registry-operator-deployment.yaml
+
 namespace: events

--- a/renovate.json
+++ b/renovate.json
@@ -6,4 +6,13 @@
   "schedule": [
     "before 6am on Monday"
   ]
+  "packageRules": [
+    {
+      "matchPaths": [
+        "deployments/sqrbot-jsick",
+        "deployments/templatebot-jsick"
+      ],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
- Drop the sqrbot-jsick development app from running; leave the manifest so it'll be easy to spin back up when needed
- Have renovate ignore these testing apps to avoid confusion with what's running.