### PR TITLE
DM-33317: Deploy strimzi-registry-operator 0.4.0

### DIFF
--- a/deployments/events/kustomization.yaml
+++ b/deployments/events/kustomization.yaml
@@ -3,13 +3,13 @@ kind: Kustomization
 
 images:
   - name: lsstsqre/strimzi-registry-operator
-    newTag: tickets-DM-33317
+    newTag: 0.4.0
 
 resources:
   - resources/kafka.yaml
   # Schema Registry
   - resources/schemaregistry-user.yaml
-  - github.com/lsst-sqre/strimzi-registry-operator.git//manifests?ref=tickets/DM-33317
+  - github.com/lsst-sqre/strimzi-registry-operator.git//manifests?ref=0.4.0
   - resources/schemaregistry.yaml
   - resources/schemas-topic.yaml
   # Kafka topics


### PR DESCRIPTION
Final deployment for DM-33317 to use the 0.4.0 release of strimzi-registry-operator