### PR TITLE
Fix strimzi-registry-operator patch

### DIFF
--- a/deployments/events/patches/strimzi-registry-operator-deployment.yaml
+++ b/deployments/events/patches/strimzi-registry-operator-deployment.yaml
@@ -2,13 +2,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: strimzi-registry-operator
-  spec:
-    template:
-      spec:
-        containers:
-          - name: operator
-            env:
-              - name: SSR_CLUSTER_NAME
-                value: events
-              - name: SSR_NAMESPACE
-                value: events
+spec:
+  template:
+    spec:
+      containers:
+        - name: operator
+          env:
+            - name: SSR_CLUSTER_NAME
+              value: events
+            - name: SSR_NAMESPACE
+              value: events


### PR DESCRIPTION
The new env settings weren't merged into the right place in the
Deployment manifest