### PR TITLE
Document kube-prometheus-stack CRD sync workaround

### DIFF
--- a/docs/ops/app-land/index.rst
+++ b/docs/ops/app-land/index.rst
@@ -17,7 +17,7 @@ app-land app deployment guide
 .. rubric:: Overview
 
 The ``app-land`` app is responsible for deploying most, if not all, of Roundtable's tenant applications.
-It follows the `app of apps <https://argoproj.github.io/argo-cd/operator-manual/cluster-bootstrapping/#app-of-apps-pattern>`_ pattern, equivalent to how the :doc:`roundtable <../roundtable/index>` application deploys core infrastructure.
+It follows the `app of apps <https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/#app-of-apps-pattern>`_ pattern, equivalent to how the :doc:`roundtable <../roundtable/index>` application deploys core infrastructure.
 
 .. rubric:: Bootstrapping the Application
 

--- a/docs/ops/argo-cd/argocd-github-sso.rst
+++ b/docs/ops/argo-cd/argocd-github-sso.rst
@@ -26,5 +26,5 @@ Currently only members of the `lsst-sqre GitHub organization`_ can log in.
 Dex, the OIDC component used by Argo CD, also supports limited access by GitHub team.
 See the `Authentication through GitHub page <https://dexidp.io/docs/connectors/github/>`__ in the Dex documentation.
 
-.. _`SSO Configuration`: https://argoproj.github.io/argo-cd/operator-manual/user-management/#sso
+.. _`SSO Configuration`: https://argo-cd.readthedocs.io/en/stable/operator-manual/user-management/#sso
 .. _`argocd-cm.yaml patch`: https://github.com/lsst-sqre/roundtable/blob/master/deployments/argo-cd/patches/argocd-cm.yaml

--- a/docs/ops/argo-cd/argocd-rbac.rst
+++ b/docs/ops/argo-cd/argocd-rbac.rst
@@ -3,7 +3,7 @@ Argo CD RBAC configuration
 ##########################
 
 This page describes the role-based access control (RBAC) configuration for the Roundtable Argo CD instance and is intended for Roundtable operators.
-For background, see `Argo CD's RBAC documentation <https://argoproj.github.io/argo-cd/operator-manual/rbac/>`_.
+For background, see `Argo CD's RBAC documentation <https://argo-cd.readthedocs.io/en/stable/operator-manual/rbac/>`_.
 
 The RBAC is configured through the `argocd-rbac-cm.yaml`_ patch.
 

--- a/docs/ops/argo-cd/helm-repositories.rst
+++ b/docs/ops/argo-cd/helm-repositories.rst
@@ -8,6 +8,6 @@ Note that the default repository (which provides the ``stable/<chart>`` charts f
 
 .. seealso::
 
-   `Helm Chart Repositories <https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#helm-chart-repositories>`_ in the Argo CD documentation.
+   `Helm Chart Repositories <https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#helm-chart-repositories>`_ in the Argo CD documentation.
 
 .. _`argocd-cm.yaml`: https://github.com/lsst-sqre/roundtable/blob/master/deployments/argo-cd/patches/argocd-cm.yaml

--- a/docs/ops/argo-cd/repositories.rst
+++ b/docs/ops/argo-cd/repositories.rst
@@ -11,7 +11,7 @@ We also include the Argo CD repository, https://github.com/argoproj/argo-cd, bec
 
 .. seealso::
 
-   `Repositories <https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#repositories>`_ in the Argo CD documentation.
+   `Repositories <https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#repositories>`_ in the Argo CD documentation.
 
 .. _`argocd-cm.yaml`: https://github.com/lsst-sqre/roundtable/blob/master/deployments/argo-cd/patches/argocd-cm.yaml
 .. _`kustomization.yaml`: https://github.com/lsst-sqre/roundtable/blob/master/deployments/argo-cd/kustomization.yaml

--- a/docs/ops/argo-cd/upgrading.rst
+++ b/docs/ops/argo-cd/upgrading.rst
@@ -6,7 +6,7 @@ To upgrade Argo CD:
 
 #. Go to the `Argo CD GitHub page <https://github.com/argoproj/argo-cd>`__ and determine the latest release.
    You can also check the Roundtable repository with ``neophile analyze`` (see the `neophile documentation <https://neophile.lsst.io/>`__ for more information).
-#. Read the `upgrade notes <https://argoproj.github.io/argo-cd/operator-manual/upgrading/overview/>`__ to see if there are any changes to adjust for.
+#. Read the `upgrade notes <https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/overview/>`__ to see if there are any changes to adjust for.
 #. Update the `Argo CD configuration <https://github.com/lsst-sqre/roundtable/blob/master/deployments/argo-cd/kustomization.yaml>`__ to point to the latest version.
    Argo CD will then sync and upgrade itself as soon as it notices the change to the repository.
 
@@ -30,7 +30,7 @@ For major upgrades, consider taking a backup before upgrading with:
 
 You have to temporarily make your ``kubectl`` configuration file world-readable so that the Argo CD Docker image can use your credentials.
 Replace ``$VERSION`` with the current Argo CD version as seen in the top left hand sidebar in the UI, with the leading ``v`` but without the ``+`` and trailing hash.
-This is taken from the `Argo CD disaster recovery documentation <https://argoproj.github.io/argo-cd/operator-manual/disaster_recovery/>`__ with the addition of the namespace flag.
+This is taken from the `Argo CD disaster recovery documentation <https://argo-cd.readthedocs.io/en/stable/operator-manual/disaster_recovery/>`__ with the addition of the namespace flag.
 
 If anything goes horribly wrong, you can then restore the configuration with:
 

--- a/docs/ops/ingress-nginx/index.rst
+++ b/docs/ops/ingress-nginx/index.rst
@@ -16,7 +16,7 @@ ingress-nginx app deployment guide
 
 .. rubric:: Overview
 
-This Argo CD Application deploys and configures `ingress-nginx <https://github.com/kubernetes/ingress-nginx>`__ from its `Helm chart repository <https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx>`__.
+This Argo CD Application deploys and configures `ingress-nginx <https://github.com/kubernetes/ingress-nginx>`__ from its `Helm chart repository <https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx>`__.
 
 .. rubric:: Upgrading
 

--- a/docs/ops/kube-prometheus-stack/grafana-github-sso.rst
+++ b/docs/ops/kube-prometheus-stack/grafana-github-sso.rst
@@ -14,6 +14,8 @@ GitHub SSO is primarily configured through the `values.yaml file`_.
 The Grafana Helm chart translates YAML into the standard `grafana.ini configuration file <https://grafana.com/docs/grafana/latest/installation/configuration/>`_.
 See the Grafana documentation on `GitHub OAuth2 Authentication <https://grafana.com/docs/grafana/latest/auth/github/>`_, specifically.
 
+.. _values.yaml file: https://github.com/lsst-sqre/roundtable/blob/master/deployments/kube-prometheus-stack/values.yaml
+
 The only part of the configuration not included in the `values.yaml file`_ is the GitHub OAuth client secret.
 This value is obtained from an environment variable override mounted from the ``grafana-env`` secret resource (see the ``envFromSecret`` field in the `values.yaml file`_).
 This secret, in turn, is created from a ``VaultSecret`` that pulls the secret information from the ``grafana`` secret in the Roundtable Vault secret tree.

--- a/docs/ops/kube-prometheus-stack/index.rst
+++ b/docs/ops/kube-prometheus-stack/index.rst
@@ -25,6 +25,10 @@ The Grafana dashboard is online at https://monitoring.roundtable.lsst.codes.
 
 The prometheus chart is large and complex, so some hand-holding may be required when upgrading it to a new upstream release.
 
+One of the custom resource definitions (CRDs) is too long for Argo CD to be able to update using its normal mechanism, so every sync that attempts to update that CRD will fail.
+To successfully sync the application, find the CRD that is failing to update, select :guilabel:`Sync` from its menu, and select :guilabel:`Replace` from the resulting sync configuration menu before syncing.
+This should successfully sync that CRD and then the rest of the application should sync correctly.
+
 You may have to delete the existing prometheus-grafana replica set to release its underlying storage, and then delete the new prometheus-grafana pod to force it to re-attempt to attach its storage.
 
 Argo CD will often not complete all updates in the first, automatically triggered pass.

--- a/docs/ops/roundtable/index.rst
+++ b/docs/ops/roundtable/index.rst
@@ -17,7 +17,7 @@ roundtable app deployment guide
 .. rubric:: Overview
 
 The ``roundtable`` app is responsible for deploying the core infrastructure of Roundtable.
-It follows the `app of apps <https://argoproj.github.io/argo-cd/operator-manual/cluster-bootstrapping/#app-of-apps-pattern>`__ pattern.
+It follows the `app of apps <https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/#app-of-apps-pattern>`__ pattern.
 It deploys:
 
 - Namespaces for core infrastructure apps.

--- a/docs/ops/security/index.rst
+++ b/docs/ops/security/index.rst
@@ -17,7 +17,7 @@ security app deployment guide
 .. rubric:: Overview
 
 The ``security`` app is responsible for deploying security services for Roundtable, most notably Vault and all of its dependencies.
-It follows the `app of apps <https://argoproj.github.io/argo-cd/operator-manual/cluster-bootstrapping/#app-of-apps-pattern>`__ pattern.
+It follows the `app of apps <https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/#app-of-apps-pattern>`__ pattern.
 It deploys:
 
 - :doc:`ingress-nginx <../ingress-nginx/index>` for shared ingress.


### PR DESCRIPTION
One of the CRDs is too long to sync normally and needs to be
manually synced with the Replace option set.  Document this.