### PR TITLE
Add templatekit and safir to neophile

### DIFF
--- a/deployments/neophile/values.yaml
+++ b/deployments/neophile/values.yaml
@@ -36,6 +36,8 @@ neophile:
       - owner: "lsst-sqre"
         repo: "rubin-tv"
       - owner: "lsst-sqre"
+        repo: "safir"
+      - owner: "lsst-sqre"
         repo: "safirdemo"
       - owner: "lsst-sqre"
         repo: "segwarides"
@@ -45,6 +47,8 @@ neophile:
         repo: "strimzi-registry-operator"
       - owner: "lsst-sqre"
         repo: "templatebot"
+      - owner: "lsst-sqre"
+        repo: "templatekit"
       # Ignore during active development
       # - owner: "lsst-sqre"
       #   repo: "times-square"


### PR DESCRIPTION
Use neophile to keep the pre-commit pins up to date.