### PR TITLE
Unpin the Vault image version

### DIFF
--- a/deployments/vault/values.yaml
+++ b/deployments/vault/values.yaml
@@ -6,9 +6,6 @@ vault:
     enabled: false
 
   server:
-    image:
-      tag: "1.9.0"
-
     ingress:
       enabled: true
       annotations:


### PR DESCRIPTION
Let the version of Vault update with the chart, since it's not
restarted automatically anyway and we can choose when to restart
it.