### PR TITLE
DM-36727: Deploy rubin-tv development image

### DIFF
--- a/deployments/rubintv/kustomization.yaml
+++ b/deployments/rubintv/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: events
 
 images:
   - name: lsstsqre/rubintv
-    newTag: 0.4.0
+    newTag: tickets-DM-36727
 
 resources:
   - github.com/lsst-sqre/rubin-tv.git//manifests/base?ref=0.4.0


### PR DESCRIPTION
This uses an authenticated bucket user again for Rubin TV.