### PR TITLE
DM-36870: Deploy rubin TV from dev branch

### DIFF
--- a/deployments/rubintv/kustomization.yaml
+++ b/deployments/rubintv/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: events
 
 images:
   - name: lsstsqre/rubintv
-    newTag: tickets-DM-36727
+    newTag: tickets-DM-36870
 
 resources:
   - github.com/lsst-sqre/rubin-tv.git//manifests/base?ref=0.4.0


### PR DESCRIPTION
This deploys Rubin TV from https://github.com/lsst-sqre/rubin-tv/pull/117