### PR TITLE
DM-37164: Add rubintv-dev application

### DIFF
--- a/deployments/app-land/kustomization.yaml
+++ b/deployments/app-land/kustomization.yaml
@@ -23,6 +23,7 @@ resources:
   - resources/sherlock-frontend.yaml
   - resources/ook.yaml
   - resources/rubintv.yaml
+  - resources/rubintv-dev.yaml
   # Test versions of apps; to re-enable these also re-enable the events API
   # for the sqrbot-jsick Slack API (via the Slack app admin API).
   # - resources/sqrbot-jsick.yaml

--- a/deployments/app-land/resources/rubintv-dev.yaml
+++ b/deployments/app-land/resources/rubintv-dev.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rubintv-dev
+  labels:
+    app: rubintv-dev
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: rubintv-dev
+spec:
+  destination:
+    namespace: rubintv-dev
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+  path: deployments/rubintv-dev
+    repoURL: https://github.com/lsst-sqre/roundtable
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true

--- a/deployments/rubintv-dev/README.md
+++ b/deployments/rubintv-dev/README.md
@@ -1,0 +1,8 @@
+# rubintv-dev
+
+This is a development instance of Rubin TV.
+For the production instance, see `rubintv`.
+
+- Status: ![](https://cd.roundtable.lsst.codes/api/badge?name=rubintv-dev)
+- Dashboard: https://cd.roundtable.lsst.codes/applications/rubintv-dev
+- Docs: https://github.com/lsst-sqre/rubintv

--- a/deployments/rubintv-dev/kustomization.yaml
+++ b/deployments/rubintv-dev/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: rubintv-dev
+
+images:
+  - name: lsstsqre/rubintv
+    newTag: develop
+
+resources:
+  - github.com/lsst-sqre/rubin-tv.git//manifests/base?ref=develop
+  - resources/secret.yaml
+  - resources/ingress.yaml
+
+patches:
+  - patches/deployment.yaml

--- a/deployments/rubintv-dev/patches/deployment.yaml
+++ b/deployments/rubintv-dev/patches/deployment.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rubintv
+spec:
+  replicas: 1

--- a/deployments/rubintv-dev/resources/ingress.yaml
+++ b/deployments/rubintv-dev/resources/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: rubintv-dev
+spec:
+  ingressClassName: 'nginx'
+  rules:
+    - host: roundtable.lsst.codes
+      http:
+        paths:
+          - path: /rubintv-dev
+            pathType: Prefix
+            backend:
+              service:
+                name: rubintv
+                port:
+                  number: 8080

--- a/deployments/rubintv-dev/resources/secret.yaml
+++ b/deployments/rubintv-dev/resources/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: rubintv
+  namespace: events
+spec:
+  path: secret/k8s_operator/roundtable/rubintv
+  type: Opaque


### PR DESCRIPTION
This is a dev instance of Rubin TV. It's a separate app from the production instance, but shares the same secrets and configuration from prod; it simply tracks the "develop" branch.

It's deployed to a separate namespace, rubintv-dev, and hosted on the /rubintv-dev/ path with its own ingress.