### PR TITLE
DM-37164: Switch rubintv-dev ingress to v1beta1 schema

### DIFF
--- a/deployments/rubintv-dev/resources/ingress.yaml
+++ b/deployments/rubintv-dev/resources/ingress.yaml
@@ -1,17 +1,15 @@
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: rubintv-dev
+  annotations:
+    kubernetes.io/ingress.class: 'nginx'
 spec:
-  ingressClassName: 'nginx'
   rules:
     - host: roundtable.lsst.codes
       http:
         paths:
           - path: /rubintv-dev
-            pathType: Prefix
             backend:
-              service:
-                name: rubintv
-                port:
-                  number: 8080
+              serviceName: rubintv
+              servicePort: 8080


### PR DESCRIPTION
rubintv-dev's ingress using the networking.k8s.io/v1 spec didn't work, so I'm trying it with the v1beta1 schema that other ingresses on Roundtable are using.