### PR TITLE
DM-37721: Add 1Password Connect server

### DIFF
--- a/deployments/1password-connect/Chart.yaml
+++ b/deployments/1password-connect/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: 1password-connect
+version: 1.0.0
+dependencies:
+  - name: connect
+    version: 1.10.0
+    repository: https://1password.github.io/connect-helm-charts/

--- a/deployments/1password-connect/README.md
+++ b/deployments/1password-connect/README.md
@@ -1,0 +1,5 @@
+# 1Password Connect
+
+- Status: ![](https://cd.roundtable.lsst.codes/api/badge?name=1password-connect)
+- Dashboard: https://cd.roundtable.lsst.codes/applications/1password-connect
+- Docs: https://roundtable.lsst.io/ops/1password-connect

--- a/deployments/1password-connect/templates/vault-secrets.yaml
+++ b/deployments/1password-connect/templates/vault-secrets.yaml
@@ -1,0 +1,8 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: "op-credentials"
+  namespace: "1password-connect"
+spec:
+  path: "secret/k8s_operator/roundtable/1password-connect"
+  type: "Opaque"

--- a/deployments/1password-connect/values.yaml
+++ b/deployments/1password-connect/values.yaml
@@ -1,0 +1,6 @@
+connect:
+  # -- Name of secret containing the 1Password credentials
+  credentialsName: "op-credentials"
+
+  # -- Name of key inside secret containing 1Password credentials
+  credentialsKey: "op-session"

--- a/deployments/app-land/kustomization.yaml
+++ b/deployments/app-land/kustomization.yaml
@@ -5,10 +5,12 @@ resources:
   # Ingress
   - resources/roundtable-ingress.yaml
   # Namespaces
+  - resources/1password-connect-ns.yaml
   - resources/lsst-the-docs-ns.yaml
   - resources/monitoring-ns.yaml
   - resources/telegraf-ns.yaml
   # Applications
+  - resources/1password-connect.yaml
   - resources/checkerboard.yaml
   - resources/lsst-the-docs.yaml
   - resources/ltdevents.yaml

--- a/deployments/app-land/resources/1password-connect-ns.yaml
+++ b/deployments/app-land/resources/1password-connect-ns.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "1password-connect"
+spec:
+  finalizers:
+    - "kubernetes"

--- a/deployments/app-land/resources/1password-connect.yaml
+++ b/deployments/app-land/resources/1password-connect.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "1password-connect"
+spec:
+  destination:
+    namespace: "1password-connect"
+    server: "https://kubernetes.default.svc"
+  project: "default"
+  source:
+    path: "deployments/1password-connect"
+    repoURL: "https://github.com/lsst-sqre/roundtable"
+    targetRevision: "HEAD"
+  syncPolicy:
+    automated:
+      prune: true

--- a/deployments/app-land/resources/roundtable-ingress.yaml
+++ b/deployments/app-land/resources/roundtable-ingress.yaml
@@ -1,49 +1,73 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: roundtable-ingress
   namespace: events
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-issuer"
 spec:
+  ingressClassName: "nginx"
   tls:
     - hosts:
-      - roundtable.lsst.codes
-      secretName: roundtable-ingress-tls
+        - "roundtable.lsst.codes"
+      secretName: "roundtable-ingress-tls"
   rules:
-    - host: roundtable.lsst.codes
+    - host: "roundtable.lsst.codes"
       http:
         paths:
-          - path: /1password
+          - path: "/1password"
+            pathType: Prefix
             backend:
-              serviceName: 1password-connect
-              servicePort: 8080
-          - path: /checkerboard
+              service:
+                name: "1password-connect"
+                port:
+                  number: 8080
+          - path: "/checkerboard"
+            pathType: Prefix
             backend:
-              serviceName: checkerboard
-              servicePort: 8080
-          - path: /ltdevents
+              service:
+                name: "checkerboard"
+                port:
+                  number: 8080
+          - path: "/ltdevents"
+            pathType: Prefix
             backend:
-              serviceName: ltdevents
-              servicePort: 8080
-          - path: /safirdemo
+              service:
+                name: "ltdevents"
+                port:
+                  number: 8080
+          - path: "/safirdemo"
+            pathType: Prefix
             backend:
-              serviceName: safirdemo
-              servicePort: 8080
-          - path: /sqrbot-jr
+              service:
+                name: "safirdemo"
+                port:
+                  number: 8080
+          - path: "/sqrbot-jr"
+            pathType: Prefix
             backend:
-              serviceName: sqrbot-jr
-              servicePort: 8080
-          - path: /sqrbot-jsick
+              service:
+                name: "sqrbot-jr"
+                port:
+                  number: 8080
+          - path: "/sqrbot-jsick"
+            pathType: Prefix
             backend:
-              serviceName: sqrbot-jsick
-              servicePort: 8080
-          - path: /segwarides
+              service:
+                name: "sqrbot-jsick"
+                port:
+                  number: 8080
+          - path: "/segwarides"
+            pathType: Prefix
             backend:
-              serviceName: segwarides
-              servicePort: 8080
-          - path: /rubintv
+              service:
+                name: "segwarides"
+                port:
+                  number: 8080
+          - path: "/rubintv"
+            pathType: Prefix
             backend:
-              serviceName: rubintv
-              servicePort: 8080
+              service:
+                name: "rubintv"
+                port:
+                  number: 8080

--- a/deployments/app-land/resources/roundtable-ingress.yaml
+++ b/deployments/app-land/resources/roundtable-ingress.yaml
@@ -15,6 +15,10 @@ spec:
     - host: roundtable.lsst.codes
       http:
         paths:
+          - path: /1password
+            backend:
+              serviceName: 1password-connect
+              servicePort: 8080
           - path: /checkerboard
             backend:
               serviceName: checkerboard

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,6 +128,10 @@ rst_epilog = """
    :target: https://cd.roundtable.lsst.codes/applications/vault-secrets-operator
    :alt: Vault Secrets Operator app status
 
+.. |1password-connect-status| image:: https://cd.roundtable.lsst.codes/api/badge?name=1password-connect
+   :target: https://cd.roundtable.lsst.codes/applications/1password-connect
+   :alt: 1password-connect app status
+
 .. _Helm: https://helm.sh
 .. _Kustomize: https://kustomize.io
 .. _Argo CD: https://argoproj.github.io/argo-cd/

--- a/docs/ops/1password-connect/index.rst
+++ b/docs/ops/1password-connect/index.rst
@@ -1,0 +1,29 @@
+######################################
+1password-connect app deployment guide
+######################################
+
+.. list-table::
+   :widths: 10,40
+
+   * - Deployment
+     - |1password-connect-status|
+   * - Edit on GitHub
+     - `/deployments/1password-connect <https://github.com/lsst-sqre/roundtable/tree/master/deployments/1password-connect>`__
+   * - Type
+     - Helm_
+   * - Parent app
+     - :doc:`roundtable <../roundtable/index>`
+
+.. rubric:: Overview
+
+The ``1password-connect`` application is an installation of `1Password Connect Server <https://developer.1password.com/docs/connect>`__.
+This server provides a REST API to a 1Password vault, which is used by `Phalanx <https://phalanx.lsst.io/>`__ for secrets management for the deployments run by SQuaRE.
+
+.. rubric:: Bootstrapping the Application
+
+1Password Connect requires a secret to talk to 1Password.
+This is managed via a ``VaultSecret`` resource installed by the Roundtable deployment.
+The ultimate source of this secret is the 1Password item ``SQuaRE Integration Credentials File`` in the SQuaRE vault.
+
+Clients of the 1Password Connect server will need to present a token for authentication.
+The initial bootstrap token is in the 1Password item ``SQuaRE Integration Access Token: Argo`` in the SQuaRE vault.

--- a/docs/ops/events/cluster-config-overview.rst
+++ b/docs/ops/events/cluster-config-overview.rst
@@ -29,7 +29,7 @@ Listeners and authentication
 ============================
 
 The cluster has an internal listener on port ``9093``, which supports mutual TLS authentication between the client and brokers.
-See `Creating a Kafka user with mutual TLS authentication <https://strimzi.io/docs/operators/latest/configuring.html#tls_client_authentication>`_ for details on how create a ``KafkaUser`` resource and use the corresponding Kubernetes ``Secret`` resource with client TLS certificates.
+See `Creating a Kafka user with mutual TLS authentication <https://strimzi.io/docs/operators/latest/configuring.html#con-securing-client-authentication-str>`_ for details on how create a ``KafkaUser`` resource and use the corresponding Kubernetes ``Secret`` resource with client TLS certificates.
 
 Authorization
 =============

--- a/docs/ops/index.rst
+++ b/docs/ops/index.rst
@@ -20,3 +20,4 @@ Although this documentation is openly available, application developers shouldn'
    strimzi/index
    vault/index
    vault-secrets-operator/index
+   1password-connect/index


### PR DESCRIPTION
We will use this server to retrieve RSP secrets from the relevant 1Password vault when bootstrapping a new Phalanx environment, or checking the secrets in an existing one.