### PR TITLE
Remove Argo CD metrics pointers

### DIFF
--- a/deployments/argo-cd/kustomization.yaml
+++ b/deployments/argo-cd/kustomization.yaml
@@ -5,10 +5,6 @@ resources:
 - https://github.com/argoproj/argo-cd/manifests/cluster-install?ref=v2.6.7
 - resources/argocd-ui-ingress.yaml
 - resources/argocd-grpc-ingress.yaml
-- resources/argocd-metrics.yaml
-- resources/argocd-server-metrics.yaml
-- resources/argocd-repo-server-metrics.yaml
-- resources/argocd-grafana-dashboard-cm.yaml
 
 patchesStrategicMerge:
 - patches/argocd-cm.yaml


### PR DESCRIPTION
We removed kube-prometheus-stack and all of these resources, but missed removing the pointers to them in kustomization.yaml.