### PR TITLE
Remove Nublado v2 services from neophile

### DIFF
--- a/deployments/neophile/values.yaml
+++ b/deployments/neophile/values.yaml
@@ -5,8 +5,6 @@ neophile:
     githubUser: "sqrbot"
     repositories:
       - owner: "lsst-sqre"
-        repo: "cachemachine"
-      - owner: "lsst-sqre"
         repo: "checkerboard"
       - owner: "lsst-sqre"
         repo: "crawlspace"
@@ -31,11 +29,7 @@ neophile:
       - owner: "lsst-sqre"
         repo: "mobu"
       - owner: "lsst-sqre"
-        repo: "moneypenny"
-      - owner: "lsst-sqre"
         repo: "neophile"
-      - owner: "lsst-sqre"
-        repo: "nublado2"
       # Ignore during active development
       # - owner: "lsst-sqre"
       #   repo: "noteburst"


### PR DESCRIPTION
cachemachine, moneypenny, and nublado2 were only used with the older version of Nublado. Now that we're getting ready to deploy the new release everywhere, stop trying to update them with neophile.