### PR TITLE
Bump version of neophile

### DIFF
--- a/deployments/neophile/Chart.yaml
+++ b/deployments/neophile/Chart.yaml
@@ -3,5 +3,5 @@ name: neophile
 version: 1.0.0
 dependencies:
   - name: neophile
-    version: 0.3.3
+    version: 0.4.0
     repository: https://lsst-sqre.github.io/charts/


### PR DESCRIPTION
The new version uses Python 3.11 instead of 3.10.