### PR TITLE
Hopefully fix Argo CD configuration

### DIFF
--- a/deployments/argo-cd/patches/argocd-server-deployment.yaml
+++ b/deployments/argo-cd/patches/argocd-server-deployment.yaml
@@ -9,7 +9,5 @@ spec:
       - name: argocd-server
         # Run argocd-server in "insecure" mode to allow ingress to do TLS.
         command:
-        - argocd-server
-        - --insecure
-        - --staticassets
-        - /shared/app
+        - /usr/local/bin/argocd-server
+        - --insecure=true


### PR DESCRIPTION
--insecure should now be --insecure=true, and upstream uses /usr/local/bin/argocd-server.  Drop --staticassets since upstream doesn't use that flag.