### PR TITLE
Remove the path to argocd-server

### DIFF
--- a/deployments/argo-cd/patches/argocd-server-deployment.yaml
+++ b/deployments/argo-cd/patches/argocd-server-deployment.yaml
@@ -8,6 +8,6 @@ spec:
       containers:
       - name: argocd-server
         # Run argocd-server in "insecure" mode to allow ingress to do TLS.
-        command:
+        args:
         - /usr/local/bin/argocd-server
         - --insecure=true


### PR DESCRIPTION
Apparently the container is run in such a way that forces the command, so command should contain only the flags.