### PR TITLE
Do not create secret for vault-secrets-operator

### DIFF
--- a/deployments/vault-secrets-operator/values.yaml
+++ b/deployments/vault-secrets-operator/values.yaml
@@ -10,5 +10,7 @@ vault-secrets-operator:
         secretKeyRef:
           name: vault-secrets-operator
           key: VAULT_TOKEN_LEASE_DURATION
+  serviceAccount:
+    createSecret: false
   vault:
     address: "https://vault.lsst.codes"


### PR DESCRIPTION
Don't create a secret for the vault-secrets-operator service account. This shouldn't be necessary and it conflicts with our secret with the Vault credentials.