### PR TITLE
Update Renovate configuration syntax

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,9 +8,9 @@
   ],
   "packageRules": [
     {
-      "matchPaths": [
-        "deployments/sqrbot-jsick",
-        "deployments/templatebot-jsick"
+      "matchFileNames": [
+        "deployments/sqrbot-jsick/**",
+        "deployments/templatebot-jsick/**"
       ],
       "enabled": false
     }


### PR DESCRIPTION
matchPaths appears to be deprecated. Switch to matchFileNames with wildcards.