### PR TITLE
Revert "Update Renovate configuration syntax"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,9 +8,9 @@
   ],
   "packageRules": [
     {
-      "matchFileNames": [
-        "deployments/sqrbot-jsick/**",
-        "deployments/templatebot-jsick/**"
+      "matchPaths": [
+        "deployments/sqrbot-jsick",
+        "deployments/templatebot-jsick"
       ],
       "enabled": false
     }


### PR DESCRIPTION
This reverts commit 5c29fbd3bb015f7f0f406bf0855336b23c89c124. Apparently Renovate is now back to running an older version?  Anyway, this produces an error and the old syntax now doesn't.