### PR TITLE
DM-42593: Update templatebot-aide

### DIFF
--- a/deployments/templatebot/kustomization.yaml
+++ b/deployments/templatebot/kustomization.yaml
@@ -17,7 +17,7 @@ patchesStrategicMerge:
 
 images:
   - name: lsstsqre/templatebot-aide
-    newTag: tickets-DM-42142
+    newTag: tickets-DM-42593
     newName: ghcr.io/lsst-sqre/templatebot-aide
 #   - name: lsstsqre/templatebot
 #     newTag: tickets-DM-32710


### PR DESCRIPTION
This development version of lsst-templatebot-aide provides
pre-validation of author_id before creating a github repo.