### PR TITLE
DM-45678: Turn off LTD and sqrbot-jr front-ends for Kubernetes cluster rotation

### DIFF
--- a/deployments/lsst-the-docs/patches/keeper-deployment.yaml
+++ b/deployments/lsst-the-docs/patches/keeper-deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: keeper-api
 spec:
-  replicas: 4
+  replicas: 0
   template:
     spec:
       containers:

--- a/deployments/sqrbot-jr/patches/deployment.yaml
+++ b/deployments/sqrbot-jr/patches/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: sqrbot
 spec:
+  replicas: 0
   template:
     spec:
       containers:


### PR DESCRIPTION
In preparation for rotating the Kubernetes cluster CA, turn down the front-ends for LTD and sqrbot-jr to drain in-flight traffic during the migration.