### PR TITLE
[DM-46295] Upgrade Strimzi in the Roundtable cluster

### DIFF
--- a/deployments/events/resources/demo-user.yaml
+++ b/deployments/events/resources/demo-user.yaml
@@ -1,4 +1,5 @@
-apiVersion: kafka.strimzi.io/v1beta1
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:
   name: demo

--- a/deployments/events/resources/kafka.yaml
+++ b/deployments/events/resources/kafka.yaml
@@ -5,7 +5,7 @@ metadata:
   name: events
 spec:
   kafka:
-    version: 2.3.0
+    version: 3.2.0
     replicas: 3
     listeners:
     - name: tls

--- a/deployments/events/resources/kafka.yaml
+++ b/deployments/events/resources/kafka.yaml
@@ -1,4 +1,5 @@
-apiVersion: kafka.strimzi.io/v1beta1
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: events
@@ -6,134 +7,127 @@ spec:
   kafka:
     version: 2.3.0
     replicas: 3
-    resources:
-      requests:
-        memory: 2Gi
-        cpu: "500m"
-      limits:
-        memory: 4Gi
-        cpu: "1"
-    template:
-      pod:
-        # Schedule Kafka broker pods on nodes labeled "dedicated: events"
-        # and tolerate the taint NoExecute dedicated=events.
-        tolerations:
-          - key: "dedicated"
-            operator: "Equal"
-            value: "events"
-            effect: "NoExecute"
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: "dedicated"
-                      operator: "In"
-                      values:
-                      - "events"
-          podAntiAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              - labelSelector:
-                  matchExpressions:
-                    - key: "strimzi.io/name"
-                      operator: "In"
-                      values:
-                        - "events-kafka"
-                topologyKey: "kubernetes.io/hostname"
-      persistentVolumeClaim:
-        metadata:
-          annotations:
-            # https://argoproj.github.io/argo-cd/user-guide/compare-options/
-            argocd.argoproj.io/compare-options: IgnoreExtraneous
-            argocd.argoproj.io/sync-options: Prune=false
-    # https://strimzi.io/docs/latest/#ref-jvm-options-deployment-configuration-kafka
-    # The recommendation is to keep the minimum (Xms) the same as the maximum
-    # (Xmx). Expect the usage to be 4.5x this value; hence the 3 to 4 Gi
-    # Kubernetes limit.
-    jvmOptions:
-      -Xms: 512M
-      -Xmx: 512M
     listeners:
-      # Enable the TLS listener (encrypted) on 9093 with mutual TLS
-      # authentication
-      # https://strimzi.io/docs/latest/#assembly-kafka-broker-listener-authentication-deployment-configuration-kafka
-      tls:
-        authentication:
-          type: tls
-    authorization:
-      # Users can access topics based on ACLs
-      # https://strimzi.io/docs/latest/#ref-kafka-authorization-deployment-configuration-kafka
-      # ACLs are configured on KafkaUser resources
-      type: simple
+    - name: tls
+      port: 9093
+      type: internal
+      tls: true
+      authentication:
+        type: tls
     config:
       auto.create.topics.enable: "false"
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "2.3"
+      log.message.format.version: 2.3
     storage:
-      # Use an SSD persistent volume for Kafka pods
       type: persistent-claim
-      class: faster
       size: 100Gi
-      deleteClaim: false
-    metrics:
-      lowercaseOutputName: true
-  zookeeper:
-    replicas: 3
+      class: faster
+    authorization:
+      type: simple
+    jvmOptions:
+      "-Xmx": 512M
+      "-Xms": 512M
     resources:
+      limits:
+        memory: 4Gi
+        cpu: 1
       requests:
         memory: 2Gi
-        cpu: "500m"
-      limits:
-        memory: 3Gi
-        cpu: "1"
+        cpu: 500m
+    metricsConfig:
+      type: jmxPrometheusExporter
+      valueFrom:
+        configMapKeyRef:
+          key: events-kafka-jmx-exporter-configuration.yaml
+          name: events-kafka-jmx-exporter-configuration
     template:
       pod:
-        # Schedule Kafka broker pods on nodes labeled "dedicated: events"
-        # and tolerate the taint NoExecute dedicated=events.
-        # (this is the same as Kafka broker scheduling; above)
-        tolerations:
-          - key: "dedicated"
-            operator: "Equal"
-            value: "events"
-            effect: "NoExecute"
         affinity:
           nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
               nodeSelectorTerms:
-                - matchExpressions:
-                    - key: "dedicated"
-                      operator: "In"
-                      values:
-                      - "events"
+              - matchExpressions:
+                - key: dedicated
+                  operator: In
+                  values:
+                  - events
           podAntiAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
-              - labelSelector:
-                  matchExpressions:
-                    - key: "strimzi.io/name"
-                      operator: "In"
-                      values:
-                        - "events-zookeeper"
-                topologyKey: "kubernetes.io/hostname"
+            - labelSelector:
+                matchExpressions:
+                - key: strimzi.io/name
+                  operator: In
+                  values:
+                  - events-kafka
+              topologyKey: kubernetes.io/hostname
+        tolerations:
+        - effect: NoExecute
+          key: dedicated
+          operator: Equal
+          value: events
       persistentVolumeClaim:
         metadata:
           annotations:
-            # https://argoproj.github.io/argo-cd/user-guide/compare-options/
             argocd.argoproj.io/compare-options: IgnoreExtraneous
             argocd.argoproj.io/sync-options: Prune=false
-    # https://strimzi.io/docs/latest/#ref-jvm-options-deployment-configuration-kafka
-    jvmOptions:
-      -Xms: 512M
-      -Xmx: 512M
+  zookeeper:
+    replicas: 3
     storage:
-      # Use an SSD persistent volume for zookeeper pods
       type: persistent-claim
-      class: faster
       size: 50Gi
-      deleteClaim: false
+      class: faster
+    jvmOptions:
+      "-Xmx": 512M
+      "-Xms": 512M
+    resources:
+      limits:
+        memory: 3Gi
+        cpu: 1
+      requests:
+        memory: 2Gi
+        cpu: 500m
+    template:
+      pod:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: dedicated
+                  operator: In
+                  values:
+                  - events
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: strimzi.io/name
+                  operator: In
+                  values:
+                  - events-zookeeper
+              topologyKey: kubernetes.io/hostname
+        tolerations:
+        - effect: NoExecute
+          key: dedicated
+          operator: Equal
+          value: events
+      persistentVolumeClaim:
+        metadata:
+          annotations:
+            argocd.argoproj.io/compare-options: IgnoreExtraneous
+            argocd.argoproj.io/sync-options: Prune=false
   entityOperator:
     topicOperator:
       watchedNamespace: events
     userOperator:
       watchedNamespace: events
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: events-kafka-jmx-exporter-configuration
+data:
+  events-kafka-jmx-exporter-configuration.yaml: |
+    lowercaseOutputName: true

--- a/deployments/events/resources/ltdevents-topics.yaml
+++ b/deployments/events/resources/ltdevents-topics.yaml
@@ -1,13 +1,12 @@
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "ltd.events"
+  name: ltd.events
   labels:
     strimzi.io/cluster: events
 spec:
   partitions: 8
   replicas: 3
   config:
-    # http://kafka.apache.org/documentation/#topicconfigs
-    retention.ms: 2592000000 # 30 days
+    retention.ms: 2592000000

--- a/deployments/events/resources/ltdevents-user.yaml
+++ b/deployments/events/resources/ltdevents-user.yaml
@@ -1,4 +1,5 @@
-apiVersion: kafka.strimzi.io/v1beta1
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:
   name: kafkauser-ltdevents
@@ -10,16 +11,15 @@ spec:
   authorization:
     type: simple
     acls:
-      # Produce ltd.events
-      - resource:
-          type: topic
-          name: "ltd.events"
-          patternType: literal
-        operation: "Write"
-        type: allow
-      - resource:
-          type: topic
-          name: "ltd.events"
-          patternType: literal
-        operation: "Describe"
-        type: allow
+    - resource:
+        type: topic
+        name: ltd.events
+        patternType: literal
+      operation: Write
+      type: allow
+    - resource:
+        type: topic
+        name: ltd.events
+        patternType: literal
+      operation: Describe
+      type: allow

--- a/deployments/events/resources/ook-topics.yaml
+++ b/deployments/events/resources/ook-topics.yaml
@@ -1,13 +1,12 @@
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "ook.ingest"
+  name: ook.ingest
   labels:
     strimzi.io/cluster: events
 spec:
   partitions: 16
   replicas: 3
   config:
-    # http://kafka.apache.org/documentation/#topicconfigs
-    retention.ms: 604800000 # 7 days
+    retention.ms: 604800000

--- a/deployments/events/resources/ook-user.yaml
+++ b/deployments/events/resources/ook-user.yaml
@@ -1,7 +1,5 @@
 ---
-# For the ook-queue consumer group
-# This user reads ltd.events and writes to ook.queue
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:
   name: kafkauser-ook-queue
@@ -13,49 +11,44 @@ spec:
   authorization:
     type: simple
     acls:
-      # Produce ook.ingest
-      - resource:
-          type: topic
-          name: "ook.ingest"
-          patternType: literal
-        operation: "Write"
-        type: "allow"
-      - resource:
-          type: topic
-          name: "ook.ingest"
-          patternType: literal
-        operation: "Describe"
-        type: "allow"
-      # Access ook-queue consumer group
-      - resource:
-          type: "group"
-          name: "ook-queue"
-          patternType: "literal"
-        operation: "Describe"
-        type: "allow"
-      - resource:
-          type: "group"
-          name: "ook-queue"
-          patternType: "literal"
-        operation: "Read"
-        type: "allow"
-      # Consume the ltd.events topic
-      - resource:
-          type: "topic"
-          name: "ltd.events"
-          patternType: "literal"
-        operation: "Read"
-        type: "allow"
-      - resource:
-          type: "topic"
-          name: "ltd.events"
-          patternType: "literal"
-        operation: "Describe"
-        type: "allow"
+    - resource:
+        type: topic
+        name: ook.ingest
+        patternType: literal
+      operation: Write
+      type: allow
+    - resource:
+        type: topic
+        name: ook.ingest
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: group
+        name: ook-queue
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: group
+        name: ook-queue
+        patternType: literal
+      operation: Read
+      type: allow
+    - resource:
+        type: topic
+        name: ltd.events
+        patternType: literal
+      operation: Read
+      type: allow
+    - resource:
+        type: topic
+        name: ltd.events
+        patternType: literal
+      operation: Describe
+      type: allow
 ---
-# For the ook-ingest consumer group
-# This user reads ook.queue
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:
   name: kafkauser-ook-ingest
@@ -67,29 +60,27 @@ spec:
   authorization:
     type: simple
     acls:
-      # Access ook-ingest consumer group
-      - resource:
-          type: "group"
-          name: "ook-ingest"
-          patternType: "literal"
-        operation: "Describe"
-        type: "allow"
-      - resource:
-          type: "group"
-          name: "ook-ingest"
-          patternType: "literal"
-        operation: "Read"
-        type: "allow"
-      # Consume the ook.ingest topic
-      - resource:
-          type: "topic"
-          name: "ook.ingest"
-          patternType: "literal"
-        operation: "Read"
-        type: "allow"
-      - resource:
-          type: "topic"
-          name: "ook.ingest"
-          patternType: "literal"
-        operation: "Describe"
-        type: "allow"
+    - resource:
+        type: group
+        name: ook-ingest
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: group
+        name: ook-ingest
+        patternType: literal
+      operation: Read
+      type: allow
+    - resource:
+        type: topic
+        name: ook.ingest
+        patternType: literal
+      operation: Read
+      type: allow
+    - resource:
+        type: topic
+        name: ook.ingest
+        patternType: literal
+      operation: Describe
+      type: allow

--- a/deployments/events/resources/schemaregistry-user.yaml
+++ b/deployments/events/resources/schemaregistry-user.yaml
@@ -1,4 +1,5 @@
-apiVersion: kafka.strimzi.io/v1beta1
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:
   name: schemaregistry
@@ -8,36 +9,29 @@ spec:
   authentication:
     type: tls
   authorization:
-    # Official docs on authorizations required for the Schema Registry:
-    # https://docs.confluent.io/current/schema-registry/security/index.html#authorizing-access-to-the-schemas-topic
     type: simple
     acls:
-      # Allow all operations on the registry-schemas topic
-      # Read, Write, and DescribeConfigs are known to be required
-      - resource:
-          type: topic
-          name: "registry-schemas"
-          patternType: literal
-        operation: All
-        type: allow
-      # Allow all operations on the schema-registry* group
-      - resource:
-          type: group
-          name: "schema-registry"
-          patternType: prefix
-        operation: All
-        type: allow
-      # Allow Describe on the __consumer_offsets topic
-      # (The official docs also mention DescribeConfigs?)
-      - resource:
-          type: topic
-          name: "__consumer_offsets"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      - resource:
-          type: topic
-          name: "__consumer_offsets"
-          patternType: literal
-        operation: "DescribeConfigs"
-        type: allow
+    - resource:
+        type: topic
+        name: registry-schemas
+        patternType: literal
+      operation: All
+      type: allow
+    - resource:
+        type: group
+        name: schema-registry
+        patternType: prefix
+      operation: All
+      type: allow
+    - resource:
+        type: topic
+        name: __consumer_offsets
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: topic
+        name: __consumer_offsets
+        patternType: literal
+      operation: DescribeConfigs
+      type: allow

--- a/deployments/events/resources/schemaregistry.yaml
+++ b/deployments/events/resources/schemaregistry.yaml
@@ -1,7 +1,8 @@
+---
 apiVersion: roundtable.lsst.codes/v1beta1
 kind: StrimziSchemaRegistry
 metadata:
   name: schemaregistry
 spec:
-  strimzi-version: v1beta1
+  strimzi-version: v1beta2
   listener: tls

--- a/deployments/events/resources/schemas-topic.yaml
+++ b/deployments/events/resources/schemas-topic.yaml
@@ -1,12 +1,12 @@
-apiVersion: kafka.strimzi.io/v1beta1
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "registry-schemas"
+  name: registry-schemas
   labels:
     strimzi.io/cluster: events
 spec:
   partitions: 1
   replicas: 3
   config:
-    # http://kafka.apache.org/documentation/#topicconfigs
-    cleanup.policy: "compact"
+    cleanup.policy: compact

--- a/deployments/events/resources/sqrbot-jr-topics.yaml
+++ b/deployments/events/resources/sqrbot-jr-topics.yaml
@@ -1,78 +1,72 @@
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "sqrbot.interaction"
+  name: sqrbot.interaction
   labels:
     strimzi.io/cluster: events
 spec:
   partitions: 4
   replicas: 3
   config:
-    # http://kafka.apache.org/documentation/#topicconfigs
-    retention.ms: 1800000  # 30 minutes
+    retention.ms: 1800000
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "sqrbot.app.mention"
+  name: sqrbot.app.mention
   labels:
     strimzi.io/cluster: events
 spec:
   partitions: 16
   replicas: 3
   config:
-    # http://kafka.apache.org/documentation/#topicconfigs
-    retention.ms: 1800000  # 30 minutes
+    retention.ms: 1800000
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "sqrbot.message.channels"
+  name: sqrbot.message.channels
   labels:
     strimzi.io/cluster: events
 spec:
   partitions: 16
   replicas: 3
   config:
-    # http://kafka.apache.org/documentation/#topicconfigs
-    retention.ms: 1800000  # 30 minutes
+    retention.ms: 1800000
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "sqrbot.message.groups"
+  name: sqrbot.message.groups
   labels:
     strimzi.io/cluster: events
 spec:
   partitions: 16
   replicas: 3
   config:
-    # http://kafka.apache.org/documentation/#topicconfigs
-    retention.ms: 1800000  # 30 minutes
+    retention.ms: 1800000
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "sqrbot.message.im"
+  name: sqrbot.message.im
   labels:
     strimzi.io/cluster: events
 spec:
   partitions: 16
   replicas: 3
   config:
-    # http://kafka.apache.org/documentation/#topicconfigs
-    retention.ms: 1800000  # 30 minutes
+    retention.ms: 1800000
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "sqrbot.message.mpim"
+  name: sqrbot.message.mpim
   labels:
     strimzi.io/cluster: events
 spec:
   partitions: 16
   replicas: 3
   config:
-    # http://kafka.apache.org/documentation/#topicconfigs
-    retention.ms: 1800000  # 30 minutes
+    retention.ms: 1800000

--- a/deployments/events/resources/sqrbot-jr-user.yaml
+++ b/deployments/events/resources/sqrbot-jr-user.yaml
@@ -1,4 +1,5 @@
-apiVersion: kafka.strimzi.io/v1beta1
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:
   name: kafkauser-sqrbot-jr
@@ -10,81 +11,75 @@ spec:
   authorization:
     type: simple
     acls:
-      # Produce sqrbot.interaction
-      - resource:
-          type: topic
-          name: "sqrbot.interaction"
-          patternType: literal
-        operation: "Write"
-        type: allow
-      - resource:
-          type: topic
-          name: "sqrbot.interaction"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      # Produce sqrbot.app.mention
-      - resource:
-          type: topic
-          name: "sqrbot.app.mention"
-          patternType: literal
-        operation: "Write"
-        type: allow
-      - resource:
-          type: topic
-          name: "sqrbot.app.mention"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      # Produce sqrbot.message.channels
-      - resource:
-          type: topic
-          name: "sqrbot.message.channels"
-          patternType: literal
-        operation: "Write"
-        type: allow
-      - resource:
-          type: topic
-          name: "sqrbot.message.channels"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      # Produce sqrbot.message.groups
-      - resource:
-          type: topic
-          name: "sqrbot.message.groups"
-          patternType: literal
-        operation: "Write"
-        type: allow
-      - resource:
-          type: topic
-          name: "sqrbot.message.groups"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      # Produce sqrbot.message.mpim
-      - resource:
-          type: topic
-          name: "sqrbot.message.mpim"
-          patternType: literal
-        operation: "Write"
-        type: allow
-      - resource:
-          type: topic
-          name: "sqrbot.message.mpim"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      # Produce sqrbot.message.im
-      - resource:
-          type: topic
-          name: "sqrbot.message.im"
-          patternType: literal
-        operation: "Write"
-        type: allow
-      - resource:
-          type: topic
-          name: "sqrbot.message.im"
-          patternType: literal
-        operation: "Describe"
-        type: allow
+    - resource:
+        type: topic
+        name: sqrbot.interaction
+        patternType: literal
+      operation: Write
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.interaction
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.app.mention
+        patternType: literal
+      operation: Write
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.app.mention
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.message.channels
+        patternType: literal
+      operation: Write
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.message.channels
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.message.groups
+        patternType: literal
+      operation: Write
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.message.groups
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.message.mpim
+        patternType: literal
+      operation: Write
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.message.mpim
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.message.im
+        patternType: literal
+      operation: Write
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.message.im
+        patternType: literal
+      operation: Describe
+      type: allow

--- a/deployments/events/resources/sqrbot-jsick-topics.yaml
+++ b/deployments/events/resources/sqrbot-jsick-topics.yaml
@@ -1,78 +1,72 @@
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "sqrbot.jsick.interaction"
+  name: sqrbot.jsick.interaction
   labels:
     strimzi.io/cluster: events
 spec:
   partitions: 4
   replicas: 3
   config:
-    # http://kafka.apache.org/documentation/#topicconfigs
-    retention.ms: 1800000  # 30 minutes
+    retention.ms: 1800000
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "sqrbot.jsick.app.mention"
-  labels:
-    strimzi.io/cluster: events
-spec:
-  partitions: 4  # test partitioning and over-partitioning consumers
-  replicas: 3
-  config:
-    # http://kafka.apache.org/documentation/#topicconfigs
-    retention.ms: 1800000  # 30 minutes
----
-apiVersion: kafka.strimzi.io/v1beta1
-kind: KafkaTopic
-metadata:
-  name: "sqrbot.jsick.message.channels"
+  name: sqrbot.jsick.app.mention
   labels:
     strimzi.io/cluster: events
 spec:
   partitions: 4
   replicas: 3
   config:
-    # http://kafka.apache.org/documentation/#topicconfigs
-    retention.ms: 1800000  # 30 minutes
+    retention.ms: 1800000
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "sqrbot.jsick.message.groups"
+  name: sqrbot.jsick.message.channels
   labels:
     strimzi.io/cluster: events
 spec:
   partitions: 4
   replicas: 3
   config:
-    # http://kafka.apache.org/documentation/#topicconfigs
-    retention.ms: 1800000  # 30 minutes
+    retention.ms: 1800000
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "sqrbot.jsick.message.im"
+  name: sqrbot.jsick.message.groups
   labels:
     strimzi.io/cluster: events
 spec:
   partitions: 4
   replicas: 3
   config:
-    # http://kafka.apache.org/documentation/#topicconfigs
-    retention.ms: 1800000  # 30 minutes
+    retention.ms: 1800000
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "sqrbot.jsick.message.mpim"
+  name: sqrbot.jsick.message.im
   labels:
     strimzi.io/cluster: events
 spec:
   partitions: 4
   replicas: 3
   config:
-    # http://kafka.apache.org/documentation/#topicconfigs
-    retention.ms: 1800000  # 30 minutes
+    retention.ms: 1800000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: sqrbot.jsick.message.mpim
+  labels:
+    strimzi.io/cluster: events
+spec:
+  partitions: 4
+  replicas: 3
+  config:
+    retention.ms: 1800000

--- a/deployments/events/resources/sqrbot-jsick-user.yaml
+++ b/deployments/events/resources/sqrbot-jsick-user.yaml
@@ -1,4 +1,5 @@
-apiVersion: kafka.strimzi.io/v1beta1
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:
   name: kafkauser-sqrbot-jsick
@@ -10,15 +11,15 @@ spec:
   authorization:
     type: simple
     acls:
-      - resource:
-          type: topic
-          name: "sqrbot.jsick"
-          patternType: prefix
-        operation: "Write"
-        type: allow
-      - resource:
-          type: topic
-          name: "sqrbot.jsick"
-          patternType: prefix
-        operation: "Describe"
-        type: allow
+    - resource:
+        type: topic
+        name: sqrbot.jsick
+        patternType: prefix
+      operation: Write
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.jsick
+        patternType: prefix
+      operation: Describe
+      type: allow

--- a/deployments/events/resources/templatebot-jsick-topics.yaml
+++ b/deployments/events/resources/templatebot-jsick-topics.yaml
@@ -1,39 +1,36 @@
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "templatebot.jsick.prerender"
+  name: templatebot.jsick.prerender
   labels:
     strimzi.io/cluster: events
 spec:
   partitions: 1
   replicas: 3
   config:
-    # http://kafka.apache.org/documentation/#topicconfigs
-    retention.ms: 86400000  # 24 hours
+    retention.ms: 86400000
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "templatebot.jsick.render-ready"
+  name: templatebot.jsick.render-ready
   labels:
     strimzi.io/cluster: events
 spec:
   partitions: 1
   replicas: 3
   config:
-    # http://kafka.apache.org/documentation/#topicconfigs
-    retention.ms: 86400000  # 24 hours
+    retention.ms: 86400000
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "templatebot.jsick.postrender"
+  name: templatebot.jsick.postrender
   labels:
     strimzi.io/cluster: events
 spec:
   partitions: 1
   replicas: 3
   config:
-    # http://kafka.apache.org/documentation/#topicconfigs
-    retention.ms: 86400000  # 24 hours
+    retention.ms: 86400000

--- a/deployments/events/resources/templatebot-jsick-user.yaml
+++ b/deployments/events/resources/templatebot-jsick-user.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:
   name: kafkauser-templatebot-jsick
@@ -11,112 +11,104 @@ spec:
   authorization:
     type: simple
     acls:
-      # Access templatebot-jsick-2 consumer group
-      - resource:
-          type: group
-          name: "templatebot-jsick-2"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      - resource:
-          type: group
-          name: "templatebot-jsick-2"
-          patternType: literal
-        operation: "Read"
-        type: allow
-      # Access templatebot-jsick-3 consumer group
-      - resource:
-          type: group
-          name: "templatebot-jsick-3"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      - resource:
-          type: group
-          name: "templatebot-jsick-3"
-          patternType: literal
-        operation: "Read"
-        type: allow
-      # consume the sqrbot.jsick.interaction topic
-      - resource:
-          type: topic
-          name: "sqrbot.jsick.interaction"
-          patternType: literal
-        operation: "Read"
-        type: allow
-      - resource:
-          type: topic
-          name: "sqrbot.jsick.interaction"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      # Consume the sqrbot.jsick.message.im topic
-      - resource:
-          type: topic
-          name: "sqrbot.jsick.message.im"
-          patternType: literal
-        operation: "Read"
-        type: allow
-      - resource:
-          type: topic
-          name: "sqrbot.jsick.message.im"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      # Consume the app_mention topic
-      - resource:
-          type: topic
-          name: "sqrbot.jsick.app.mention"
-          patternType: literal
-        operation: "Read"
-        type: allow
-      - resource:
-          type: topic
-          name: "sqrbot.jsick.app.mention"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      # Consume the render-ready topic
-      - resource:
-          type: topic
-          name: "templatebot.jsick.render-ready"
-          patternType: literal
-        operation: "Read"
-        type: allow
-      - resource:
-          type: topic
-          name: "templatebot.jsick.render-ready"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      # Produce the prerender topic
-      - resource:
-          type: topic
-          name: "templatebot.jsick.prerender"
-          patternType: literal
-        operation: "Write"
-        type: allow
-      - resource:
-          type: topic
-          name: "templatebot.jsick.prerender"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      # Produce the postrender topic
-      - resource:
-          type: topic
-          name: "templatebot.jsick.postrender"
-          patternType: literal
-        operation: "Write"
-        type: allow
-      - resource:
-          type: topic
-          name: "templatebot.jsick.postrender"
-          patternType: literal
-        operation: "Describe"
-        type: allow
+    - resource:
+        type: group
+        name: templatebot-jsick-2
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: group
+        name: templatebot-jsick-2
+        patternType: literal
+      operation: Read
+      type: allow
+    - resource:
+        type: group
+        name: templatebot-jsick-3
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: group
+        name: templatebot-jsick-3
+        patternType: literal
+      operation: Read
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.jsick.interaction
+        patternType: literal
+      operation: Read
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.jsick.interaction
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.jsick.message.im
+        patternType: literal
+      operation: Read
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.jsick.message.im
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.jsick.app.mention
+        patternType: literal
+      operation: Read
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.jsick.app.mention
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.jsick.render-ready
+        patternType: literal
+      operation: Read
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.jsick.render-ready
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.jsick.prerender
+        patternType: literal
+      operation: Write
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.jsick.prerender
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.jsick.postrender
+        patternType: literal
+      operation: Write
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.jsick.postrender
+        patternType: literal
+      operation: Describe
+      type: allow
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:
   name: kafkauser-templatebot-aide-jsick
@@ -128,55 +120,51 @@ spec:
   authorization:
     type: simple
     acls:
-      # Common for consumers
-      - resource:
-          type: group
-          name: "templatebot-aide-jsick"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      - resource:
-          type: group
-          name: "templatebot-aide-jsick"
-          patternType: literal
-        operation: "Read"
-        type: allow
-      # Consume the prerender topic
-      - resource:
-          type: topic
-          name: "templatebot.jsick.prerender"
-          patternType: literal
-        operation: "Read"
-        type: allow
-      - resource:
-          type: topic
-          name: "templatebot.jsick.prerender"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      # Consume the postrender topic
-      - resource:
-          type: topic
-          name: "templatebot.jsick.postrender"
-          patternType: literal
-        operation: "Read"
-        type: allow
-      - resource:
-          type: topic
-          name: "templatebot.jsick.postrender"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      # Produce the render-ready topic
-      - resource:
-          type: topic
-          name: "templatebot.jsick.render-ready"
-          patternType: literal
-        operation: "Write"
-        type: allow
-      - resource:
-          type: topic
-          name: "templatebot.jsick.render-ready"
-          patternType: literal
-        operation: "Describe"
-        type: allow
+    - resource:
+        type: group
+        name: templatebot-aide-jsick
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: group
+        name: templatebot-aide-jsick
+        patternType: literal
+      operation: Read
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.jsick.prerender
+        patternType: literal
+      operation: Read
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.jsick.prerender
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.jsick.postrender
+        patternType: literal
+      operation: Read
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.jsick.postrender
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.jsick.render-ready
+        patternType: literal
+      operation: Write
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.jsick.render-ready
+        patternType: literal
+      operation: Describe
+      type: allow

--- a/deployments/events/resources/templatebot-topics.yaml
+++ b/deployments/events/resources/templatebot-topics.yaml
@@ -1,39 +1,36 @@
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "templatebot.prerender"
+  name: templatebot.prerender
   labels:
     strimzi.io/cluster: events
 spec:
   partitions: 1
   replicas: 3
   config:
-    # http://kafka.apache.org/documentation/#topicconfigs
-    retention.ms: 86400000  # 24 hours
+    retention.ms: 86400000
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "templatebot.render-ready"
+  name: templatebot.render-ready
   labels:
     strimzi.io/cluster: events
 spec:
   partitions: 1
   replicas: 3
   config:
-    # http://kafka.apache.org/documentation/#topicconfigs
-    retention.ms: 86400000  # 24 hours
+    retention.ms: 86400000
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "templatebot.postrender"
+  name: templatebot.postrender
   labels:
     strimzi.io/cluster: events
 spec:
   partitions: 1
   replicas: 3
   config:
-    # http://kafka.apache.org/documentation/#topicconfigs
-    retention.ms: 86400000  # 24 hours
+    retention.ms: 86400000

--- a/deployments/events/resources/templatebot-user.yaml
+++ b/deployments/events/resources/templatebot-user.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:
   name: kafkauser-templatebot
@@ -11,99 +11,92 @@ spec:
   authorization:
     type: simple
     acls:
-      # Access templatebot consumer group
-      - resource:
-          type: group
-          name: "templatebot"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      - resource:
-          type: group
-          name: "templatebot"
-          patternType: literal
-        operation: "Read"
-        type: allow
-      # consume the sqrbot.interaction topic
-      - resource:
-          type: topic
-          name: "sqrbot.interaction"
-          patternType: literal
-        operation: "Read"
-        type: allow
-      - resource:
-          type: topic
-          name: "sqrbot.interaction"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      # Consume the sqrbot.message.im topic
-      - resource:
-          type: topic
-          name: "sqrbot.message.im"
-          patternType: literal
-        operation: "Read"
-        type: allow
-      - resource:
-          type: topic
-          name: "sqrbot.message.im"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      # Consume the app_mention topic
-      - resource:
-          type: topic
-          name: "sqrbot.app.mention"
-          patternType: literal
-        operation: "Read"
-        type: allow
-      - resource:
-          type: topic
-          name: "sqrbot.app.mention"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      # Consume the render-ready topic
-      - resource:
-          type: topic
-          name: "templatebot.render-ready"
-          patternType: literal
-        operation: "Read"
-        type: allow
-      - resource:
-          type: topic
-          name: "templatebot.render-ready"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      # Produce the prerender topic
-      - resource:
-          type: topic
-          name: "templatebot.prerender"
-          patternType: literal
-        operation: "Write"
-        type: allow
-      - resource:
-          type: topic
-          name: "templatebot.prerender"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      # Produce the postrender topic
-      - resource:
-          type: topic
-          name: "templatebot.postrender"
-          patternType: literal
-        operation: "Write"
-        type: allow
-      - resource:
-          type: topic
-          name: "templatebot.postrender"
-          patternType: literal
-        operation: "Describe"
-        type: allow
+    - resource:
+        type: group
+        name: templatebot
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: group
+        name: templatebot
+        patternType: literal
+      operation: Read
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.interaction
+        patternType: literal
+      operation: Read
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.interaction
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.message.im
+        patternType: literal
+      operation: Read
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.message.im
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.app.mention
+        patternType: literal
+      operation: Read
+      type: allow
+    - resource:
+        type: topic
+        name: sqrbot.app.mention
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.render-ready
+        patternType: literal
+      operation: Read
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.render-ready
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.prerender
+        patternType: literal
+      operation: Write
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.prerender
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.postrender
+        patternType: literal
+      operation: Write
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.postrender
+        patternType: literal
+      operation: Describe
+      type: allow
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:
   name: kafkauser-templatebot-aide
@@ -115,55 +108,51 @@ spec:
   authorization:
     type: simple
     acls:
-      # Common for consumers
-      - resource:
-          type: group
-          name: "templatebot-aide"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      - resource:
-          type: group
-          name: "templatebot-aide"
-          patternType: literal
-        operation: "Read"
-        type: allow
-      # Consume the prerender topic
-      - resource:
-          type: topic
-          name: "templatebot.prerender"
-          patternType: literal
-        operation: "Read"
-        type: allow
-      - resource:
-          type: topic
-          name: "templatebot.prerender"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      # Consume the postrender topic
-      - resource:
-          type: topic
-          name: "templatebot.postrender"
-          patternType: literal
-        operation: "Read"
-        type: allow
-      - resource:
-          type: topic
-          name: "templatebot.postrender"
-          patternType: literal
-        operation: "Describe"
-        type: allow
-      # Produce the render-ready topic
-      - resource:
-          type: topic
-          name: "templatebot.render-ready"
-          patternType: literal
-        operation: "Write"
-        type: allow
-      - resource:
-          type: topic
-          name: "templatebot.render-ready"
-          patternType: literal
-        operation: "Describe"
-        type: allow
+    - resource:
+        type: group
+        name: templatebot-aide
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: group
+        name: templatebot-aide
+        patternType: literal
+      operation: Read
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.prerender
+        patternType: literal
+      operation: Read
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.prerender
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.postrender
+        patternType: literal
+      operation: Read
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.postrender
+        patternType: literal
+      operation: Describe
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.render-ready
+        patternType: literal
+      operation: Write
+      type: allow
+    - resource:
+        type: topic
+        name: templatebot.render-ready
+        patternType: literal
+      operation: Describe
+      type: allow

--- a/deployments/strimzi/Chart.yaml
+++ b/deployments/strimzi/Chart.yaml
@@ -3,5 +3,5 @@ name: strimzi
 version: 1.0.0
 dependencies:
   - name: strimzi-kafka-operator
-    version: 0.14.0
+    version: 0.29.0
     repository: https://strimzi.io/charts/

--- a/deployments/strimzi/values.yaml
+++ b/deployments/strimzi/values.yaml
@@ -2,4 +2,3 @@ strimzi-kafka-operator:
   # Namespaces with a Kafka deployment
   watchNamespaces:
     - "events"
-    - "events-dev"


### PR DESCRIPTION
This PR is a multi-version upgrade attempt to bring Strimzi to a version compatible with Kubernetes 1.27.11. 
We run the [Strimzi API conversion tool](https://strimzi.io/docs/operators/0.24.0/deploying#proc-upgrade-cli-tool-files-str) to make Strimzi resources compatible with `v1beta2` .
[Strimzi 0.29.0](https://strimzi.io/downloads/) is the minimal version compatible with Kubernetes 1.27.11.
We avoid upgrading Strimzi to a more recent version to minimize changes, for example the introduction of the Unidirectional Topic Operator and Kraft. 
