### PR TITLE
Disable LTD Events generation with LTD Keeper

### DIFF
--- a/deployments/lsst-the-docs/patches/keeper-deployment.yaml
+++ b/deployments/lsst-the-docs/patches/keeper-deployment.yaml
@@ -9,12 +9,6 @@ spec:
       containers:
         - name: app
           env:
-            - name: LTD_EVENTS_URL
-              value: "http://ltdevents.events:8080/webhook"
-        - name: app
-          env:
-            - name: LTD_EVENTS_URL
-              value: "http://ltdevents.events:8080/webhook"
             - name: LTD_KEEPER_PROXY_FIX
               valueFrom:
                 configMapKeyRef:
@@ -49,8 +43,6 @@ spec:
       containers:
         - name: app
           env:
-            - name: LTD_EVENTS_URL
-              value: "http://ltdevents.events:8080/webhook"
             - name: LTD_KEEPER_PROXY_FIX
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
We no longer consume any of these events, so we'll turn off LTD Events for LTD Keeper. This should obviate any issues when Roundtable's Kafka or Schema Registry are down.